### PR TITLE
Admin API 개발 및 이벤트 스케줄러 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     // AWS
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation 'software.amazon.awssdk:s3:2.20.26'
+    // Quartz
+    implementation 'org.springframework.boot:spring-boot-starter-quartz:3.5.3'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/controller/EventAdminController.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/controller/EventAdminController.java
@@ -1,9 +1,13 @@
 package inu.codin.codinticketingapi.domain.admin.controller;
 
 import inu.codin.codinticketingapi.common.response.SingleResponse;
+import inu.codin.codinticketingapi.domain.admin.dto.request.EventCreateRequest;
+import inu.codin.codinticketingapi.domain.admin.dto.request.EventUpdateRequest;
+import inu.codin.codinticketingapi.domain.admin.dto.response.EventParticipationProfilePageResponse;
+import inu.codin.codinticketingapi.domain.admin.dto.response.EventResponse;
+import inu.codin.codinticketingapi.domain.admin.dto.response.EventStockResponse;
 import inu.codin.codinticketingapi.domain.admin.service.EventAdminService;
-import inu.codin.codinticketingapi.domain.admin.dto.EventCreateRequest;
-import inu.codin.codinticketingapi.domain.admin.dto.EventUpdateRequest;
+import inu.codin.codinticketingapi.domain.ticketing.dto.response.EventPageResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -15,78 +19,132 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("/ticketing/event")
+@RequestMapping("/admin/event")
 @RequiredArgsConstructor
-@Tag(name = "Event API", description = "티켓팅 이벤트 API")
+@Tag(name = "admin API", description = "admin API")
 public class EventAdminController {
 
     private final EventAdminService eventAdminService;
 
-    // todo: 수령자 관리에서 서명보기 기능
-    // todo: 관리자가 수동으로 수령완료 변경 기능
-    // todo: 관리자 티켓팅 잔여수량, 수령대기
-    // todo: 관리자가 사용자 티켓팅 취소
-
-    /** 티켓팅 관리자 - 티켓팅 리스트 조회 */
-    @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
-    @GetMapping("/management")
-    public ResponseEntity<SingleResponse<?>> getEventListByManager(
-            @RequestParam("page") @NotNull int pageNumber
-    ) {
-        return ResponseEntity.ok(new SingleResponse<>(200, "[티켓팅 관리자] 이벤트 게시물 리스트 반환 성공",
-                eventAdminService.getEventListByManager(pageNumber)));
-    }
-
-    /** 티켓팅 이벤트 비밀번호 탐색 */
-    @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
-    @GetMapping("/{eventId}/password")
-    public ResponseEntity<SingleResponse<?>> getEventPassword(
-            @PathVariable Long eventId
-    ) {
-        return ResponseEntity.ok(new SingleResponse<>(200, "티켓팅 이벤트 비밀번호 반환 성공",
-                eventAdminService.getEventPassword(eventId)));
-    }
-
-    // todo: 티켓팅 이벤트 마감 - 마감시 더이상 유저(트래픽)를 받지 않음
-    @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
-    @PostMapping("/{eventId}/close")
-    public ResponseEntity<SingleResponse<?>> closeEvent(
-            @PathVariable String eventId
-    ) {
-        // eventAdminService.closeEvent(eventId);
-        return ResponseEntity.ok(new SingleResponse<>(200, "티켓팅 이벤트 마감 성공", null));
-    }
-
-    /** 티켓팅 이벤트 생성 */
+    /**
+     * 티켓팅 이벤트 생성
+     */
     @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
     @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<SingleResponse<?>> createEvent(
+    public ResponseEntity<SingleResponse<EventResponse>> createEvent(
             @RequestPart("eventContent") @Valid EventCreateRequest eventCreateRequest,
-            @RequestPart(value = "eventImage") MultipartFile eventImage
-    ) {
-        return ResponseEntity.ok(new SingleResponse<>(200, "티켓팅 이벤트 생성 성공",
+            @RequestPart(value = "eventImage") MultipartFile eventImage) {
+
+        return ResponseEntity.ok(new SingleResponse<>(201, "티켓팅 이벤트 생성 성공",
                 eventAdminService.createEvent(eventCreateRequest, eventImage)));
     }
 
-    /** 티켓팅 이벤트 수정 */
+    /**
+     * 티켓팅 관리자 - 티켓팅 리스트 조회
+     */
+    @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
+    @GetMapping("/list")
+    public ResponseEntity<SingleResponse<EventPageResponse>> getEventListByManager(@RequestParam String status, @RequestParam("page") @NotNull int pageNumber) {
+
+        return ResponseEntity.ok(new SingleResponse<>(200, "[티켓팅 관리자] 이벤트 게시물 리스트 반환 성공",
+                eventAdminService.getEventListByManager(status, pageNumber)));
+    }
+
+    /**
+     * 티켓팅 이벤트 수정
+     */
     @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
     @PutMapping(value = "/{eventId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<SingleResponse<?>> updateEvent(
+    public ResponseEntity<SingleResponse<EventResponse>> updateEvent(
             @PathVariable Long eventId,
             @RequestBody EventUpdateRequest eventUpdateRequest,
-            @RequestPart(value = "eventImage", required = false) MultipartFile eventImage
-    ) {
+            @RequestPart(value = "eventImage", required = false) MultipartFile eventImage) {
+
         return ResponseEntity.ok(new SingleResponse<>(200, "티켓팅 이벤트 수정 성공",
                 eventAdminService.updateEvent(eventId, eventUpdateRequest, eventImage)));
     }
 
-    /** 티켓팅 이벤트 삭제 */
+    /**
+     * 티켓팅 이벤트 삭제
+     */
     @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
     @DeleteMapping("/{eventId}")
-    public ResponseEntity<SingleResponse<?>> deleteEvent(
-            @PathVariable Long eventId
-    ) {
+    public ResponseEntity<SingleResponse<Boolean>> deleteEvent(@PathVariable Long eventId) {
         eventAdminService.deleteEvent(eventId);
-        return ResponseEntity.ok(new SingleResponse<>(200, "티켓팅 이벤트 삭제 성공", null));
+
+        return ResponseEntity.ok(new SingleResponse<>(200, "티켓팅 이벤트 삭제 성공", true));
+    }
+
+    /**
+     * 티켓팅 이벤트 비밀번호 탐색
+     */
+    @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
+    @GetMapping("/{eventId}/password")
+    public ResponseEntity<SingleResponse<String>> getEventPassword(@PathVariable Long eventId) {
+
+        return ResponseEntity.ok(new SingleResponse<>(200, "티켓팅 이벤트 비밀번호 반환 성공",
+                eventAdminService.getEventPassword(eventId)));
+    }
+
+    /**
+     * 티켓팅 마감
+     */
+    @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
+    @PostMapping("/{eventId}/close")
+    public ResponseEntity<SingleResponse<Boolean>> closeEvent(@PathVariable Long eventId) {
+        eventAdminService.closeEvent(eventId);
+
+        return ResponseEntity.ok(new SingleResponse<>(200, "티켓팅 이벤트 마감 성공", true));
+    }
+
+    /**
+     * 수령자 리스트 조회
+     */
+    @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
+    @GetMapping("/{eventId}/participation")
+    public ResponseEntity<SingleResponse<EventParticipationProfilePageResponse>> getEventPart(@PathVariable Long eventId, @RequestParam("page") @NotNull int pageNumber) {
+
+        return ResponseEntity.ok(new SingleResponse<>(200, "이벤트 참여 인원 반환 성공",
+                eventAdminService.getParticipationList(eventId, pageNumber)));
+    }
+
+    /**
+     * 관리자가 수령 상태 변경 기능
+     */
+    @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
+    @GetMapping("{eventId}/management/status/{userId}")
+    public ResponseEntity<SingleResponse<Boolean>> changeReceiveStatus(@PathVariable Long eventId, @PathVariable String userId) {
+
+        return ResponseEntity.ok(new SingleResponse<>(200, "수령완료 변경 성공", eventAdminService.changeReceiveStatus(eventId, userId)));
+    }
+
+    /**
+     * 상품 잔여 수량 업데이트
+     */
+    @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
+    @GetMapping("{eventId}/management/stock")
+    public ResponseEntity<SingleResponse<EventStockResponse>> getStock(@PathVariable Long eventId) {
+
+        return ResponseEntity.ok(new SingleResponse<>(200, "티켓 및 상품 잔려 수령 반환 성공", eventAdminService.getStock(eventId)));
+    }
+
+    /**
+     * 관리자가 사용자 티켓팅 취소
+     */
+    @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
+    @DeleteMapping("{eventId}/management/cancel/{userId}")
+    public ResponseEntity<SingleResponse<Boolean>> cancelTicket(@PathVariable Long eventId, @PathVariable String userId) {
+
+        return ResponseEntity.ok(new SingleResponse<>(200, "사용자 티켓 취소 성공", eventAdminService.cancelTicket(eventId, userId)));
+    }
+
+    /**
+     * 관리자가 이벤트 수동 오픈
+     */
+    @PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
+    @GetMapping("/{eventId}/open")
+    public ResponseEntity<SingleResponse<Boolean>> openEvent(@PathVariable Long eventId) {
+
+        return ResponseEntity.ok(new SingleResponse<>(200, "이벤트 수동 오픈 성공", eventAdminService.openEvent(eventId)));
     }
 }

--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/dto/request/EventCreateRequest.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/dto/request/EventCreateRequest.java
@@ -1,4 +1,4 @@
-package inu.codin.codinticketingapi.domain.admin.dto;
+package inu.codin.codinticketingapi.domain.admin.dto.request;
 
 import inu.codin.codinticketingapi.domain.ticketing.entity.Campus;
 import inu.codin.codinticketingapi.domain.admin.entity.Event;
@@ -56,7 +56,6 @@ public class EventCreateRequest {
                 .eventImageUrl(eventImageUrl)
                 .title(this.title)
                 .locationInfo(this.locationInfo)
-                .quantity(this.quantity)
                 .target(this.target)
                 .description(this.description)
                 .inquiryNumber(this.inquiryNumber)

--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/dto/request/EventUpdateRequest.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/dto/request/EventUpdateRequest.java
@@ -1,4 +1,4 @@
-package inu.codin.codinticketingapi.domain.admin.dto;
+package inu.codin.codinticketingapi.domain.admin.dto.request;
 
 import inu.codin.codinticketingapi.domain.ticketing.entity.Campus;
 import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingErrorCode;

--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/dto/response/EventParticipationProfilePageResponse.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/dto/response/EventParticipationProfilePageResponse.java
@@ -1,0 +1,18 @@
+package inu.codin.codinticketingapi.domain.admin.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class EventParticipationProfilePageResponse {
+    private List<EventParticipationProfileResponse> eventParticipationProfileResponseList;
+    private int lastPage;
+    private int nextPage;
+
+    public static EventParticipationProfilePageResponse of(List<EventParticipationProfileResponse> list, int lastPage, int nextPage) {
+        return new EventParticipationProfilePageResponse(list, lastPage, nextPage);
+    }
+}

--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/dto/response/EventParticipationProfileResponse.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/dto/response/EventParticipationProfileResponse.java
@@ -1,0 +1,28 @@
+package inu.codin.codinticketingapi.domain.admin.dto.response;
+
+import inu.codin.codinticketingapi.domain.ticketing.entity.Department;
+import inu.codin.codinticketingapi.domain.ticketing.entity.Profile;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class EventParticipationProfileResponse {
+    private String userId;
+    private String name;
+    private String studentId;
+    private Department department;
+    private String imageURL;
+
+    public static EventParticipationProfileResponse of(Profile profile, String imageURL) {
+        return EventParticipationProfileResponse.builder()
+                .userId(profile.getUserId())
+                .name(profile.getName())
+                .studentId(profile.getStudentId())
+                .department(profile.getDepartment())
+                .imageURL(imageURL)
+                .build();
+    }
+}

--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/dto/response/EventResponse.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/dto/response/EventResponse.java
@@ -1,0 +1,46 @@
+package inu.codin.codinticketingapi.domain.admin.dto.response;
+
+import inu.codin.codinticketingapi.domain.admin.entity.Event;
+import inu.codin.codinticketingapi.domain.admin.entity.EventStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+public class EventResponse {
+    private Long id;
+    private String campus;
+    private LocalDateTime eventTime;
+    private LocalDateTime eventEndTime;
+    private String eventImageUrl;
+    private String title;
+    private String locationInfo;
+    private int stock;
+    private String target;
+    private String description;
+    private String inquiryNumber;
+    private String promotionLink;
+    private EventStatus status;
+
+    public static EventResponse of(Event event) {
+        return EventResponse.builder()
+                .id(event.getId())
+                .campus(event.getCampus().getDescription())
+                .eventTime(event.getEventTime())
+                .eventEndTime(event.getEventEndTime())
+                .eventImageUrl(event.getEventImageUrl())
+                .title(event.getTitle())
+                .locationInfo(event.getLocationInfo())
+                .stock(event.getStock().getStock())
+                .target(event.getTarget())
+                .description(event.getDescription())
+                .inquiryNumber(event.getInquiryNumber())
+                .promotionLink(event.getPromotionLink())
+                .status(event.getEventStatus())
+                .build();
+    }
+}

--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/dto/response/EventStockResponse.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/dto/response/EventStockResponse.java
@@ -1,0 +1,18 @@
+package inu.codin.codinticketingapi.domain.admin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class EventStockResponse {
+    private int eventStock;
+
+    public static EventStockResponse of(int eventStock) {
+        return EventStockResponse.builder()
+                .eventStock(eventStock)
+                .build();
+    }
+}

--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/entity/EventStatus.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/entity/EventStatus.java
@@ -1,0 +1,5 @@
+package inu.codin.codinticketingapi.domain.admin.entity;
+
+public enum EventStatus {
+    UPCOMING, ACTIVE, ENDED
+}

--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/scheduler/EventEndJob.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/scheduler/EventEndJob.java
@@ -1,0 +1,40 @@
+package inu.codin.codinticketingapi.domain.admin.scheduler;
+
+import inu.codin.codinticketingapi.domain.admin.entity.EventStatus;
+import inu.codin.codinticketingapi.domain.ticketing.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.*;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventEndJob implements Job {
+    private final EventRepository eventRepository;
+
+    @Override
+    @Transactional
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        Long eventId = context.getJobDetail().getJobDataMap().getLong("eventId");
+        log.info("EventEndJob 실행: Event ID = {}", eventId);
+
+        eventRepository.findById(eventId).ifPresent(event -> {
+            if (event.getEventStatus() == EventStatus.ACTIVE) {
+                event.updateStatus(EventStatus.ENDED);
+                log.info("이벤트 종료 Event ID = {}, 현재 상태: {}", eventId, event.getEventStatus());
+
+                try {
+                    Scheduler scheduler = context.getScheduler();
+                    scheduler.deleteJob(context.getJobDetail().getKey());
+                    log.info("EventEndJob 삭제 완료: Event ID = {}", eventId);
+                } catch (SchedulerException e) {
+                    log.error("EventEndJob 삭제 중 오류 발생: Event ID = {}", eventId, e);
+                }
+            } else {
+                log.warn("이벤트 종료 Job 실행되었으나, 이벤트 상태가 ACTIVE가 아님. Event ID = {}, 현재 상태: {}", eventId, event.getEventStatus());
+            }
+        });
+    }
+}

--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/scheduler/EventStartJob.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/scheduler/EventStartJob.java
@@ -1,0 +1,40 @@
+package inu.codin.codinticketingapi.domain.admin.scheduler;
+
+import inu.codin.codinticketingapi.domain.admin.entity.EventStatus;
+import inu.codin.codinticketingapi.domain.ticketing.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.*;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventStartJob implements Job {
+    private final EventRepository eventRepository;
+
+    @Override
+    @Transactional
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        Long eventId = context.getJobDetail().getJobDataMap().getLong("eventId");
+        log.info("EventStartJob 실행: Event ID = {}", eventId);
+
+        eventRepository.findById(eventId).ifPresent(event -> {
+            if (event.getEventStatus() == EventStatus.UPCOMING) {
+                event.updateStatus(EventStatus.ACTIVE);
+                log.info("이벤트 시작 Event ID = {}, 현재 상태: {}", eventId, event.getEventStatus());
+
+                try {
+                    Scheduler scheduler = context.getScheduler();
+                    scheduler.deleteJob(context.getJobDetail().getKey());
+                    log.info("EventStartJob 삭제 완료: Event ID = {}", eventId);
+                } catch (SchedulerException e) {
+                    log.error("EventStartJob 삭제 중 오류 발생: Event ID = {}", eventId, e);
+                }
+            } else {
+                log.warn("이벤트 시작 Job 실행되었으나, 이벤트 상태가 UPCOMING이 아님. Event ID = {}, 현재 상태: {}", eventId, event.getEventStatus());
+            }
+        });
+    }
+}

--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/scheduler/EventStatusScheduler.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/scheduler/EventStatusScheduler.java
@@ -1,0 +1,134 @@
+package inu.codin.codinticketingapi.domain.admin.scheduler;
+
+import inu.codin.codinticketingapi.domain.admin.entity.Event;
+import inu.codin.codinticketingapi.domain.admin.entity.EventStatus;
+import inu.codin.codinticketingapi.domain.ticketing.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.*;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+import static org.quartz.JobBuilder.newJob;
+import static org.quartz.TriggerBuilder.newTrigger;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventStatusScheduler implements ApplicationRunner {
+
+    private final Scheduler scheduler;
+    private final EventRepository eventRepository;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        scheduleUpcomingEvents();
+    }
+
+    public void scheduleCreateOrUpdatedEvent(Event event) {
+        try {
+            scheduler.deleteJob(new JobKey("startJob-" + event.getId(), "event-status"));
+            scheduler.deleteJob(new JobKey("endJob-" + event.getId(), "event-status"));
+
+            if (event.getEventStatus() == EventStatus.UPCOMING && event.getEventTime().isAfter(LocalDateTime.now())) {
+                JobDetail startJobDetail = createStartJob(event);
+                Trigger startTrigger = createStartTrigger(event);
+                scheduler.scheduleJob(startJobDetail, startTrigger);
+                log.info("새/업데이트 이벤트 시작 Job 스케줄링: ID = {}", event.getId());
+
+                JobDetail endJobDetail = createEndJob(event);
+                Trigger endTrigger = createEndTrigger(event);
+                scheduler.scheduleJob(endJobDetail, endTrigger);
+                log.info("새/업데이트 이벤트 종료 Job 스케줄링: ID = {}", event.getId());
+            } else {
+                log.info("이벤트 ID {}는 UPCOMING 상태가 아니거나 이미 시작 시간이 지났으므로 스케줄링하지 않습니다.", event.getId());
+            }
+        } catch (SchedulerException e) {
+            log.error("이벤트 스케줄 삭제 중 오류 발생: Event ID = {}", event.getId(), e);
+        }
+    }
+
+    private void scheduleUpcomingEvents() {
+        List<Event> upcomingEvents = eventRepository.findByEventStatusAndEventTimeAfter(EventStatus.UPCOMING, LocalDateTime.now());
+
+        if (upcomingEvents.isEmpty()) {
+            log.info("스케줄링할 UPCOMING 이벤트가 없습니다.");
+            return;
+        }
+
+        for (Event event : upcomingEvents) {
+            try {
+                JobDetail startJobDetail = createStartJob(event);
+                Trigger startTrigger = createStartTrigger(event);
+
+                scheduler.scheduleJob(startJobDetail, startTrigger);
+                log.info("이벤트 시작 Job 스케줄링 완료: Event ID = {}, 시작 시간 = {}", event.getId(), event.getEventTime());
+
+                JobDetail endJobDetail = createEndJob(event);
+                Trigger endTrigger = createEndTrigger(event);
+
+                scheduler.scheduleJob(endJobDetail, endTrigger);
+                log.info("이벤트 종료 Job 스케줄링 완료: Event ID = {}, 종료 시간 = {}", event.getId(), event.getEventEndTime());
+
+            } catch (SchedulerException e) {
+                log.error("이벤트 스케줄링 중 오류 발생: Event ID = {}", event.getId(), e);
+            }
+        }
+        log.info("모든 UPCOMING 이벤트 스케줄링 완료.");
+    }
+
+    public void schedulerDeleteOpenEvent(Long eventId) {
+        try {
+            scheduler.deleteJob(new JobKey("startJob-" + eventId, "event-status"));
+
+        } catch (SchedulerException e) {
+            log.error("이벤트 시작 Job 삭제 중 오류 발생: Event ID = {}", eventId, e);
+        }
+    }
+
+    public void scheduleAllDelete(Event event) {
+        try {
+            scheduler.deleteJob(new JobKey("startJob-" + event.getId(), "event-status"));
+            scheduler.deleteJob(new JobKey("endJob-" + event.getId(), "event-status"));
+            event.closeEvent();
+        } catch (SchedulerException e) {
+            log.error("새/업데이트 이벤트 스케줄링 중 오류 발생: Event ID = {}", event.getId(), e);
+        }
+    }
+
+    private JobDetail createStartJob(Event event) {
+        return newJob(EventStartJob.class)
+                .withIdentity("startJob-" + event.getId(), "event-status")
+                .usingJobData("eventId", event.getId())
+                .build();
+    }
+
+    private Trigger createStartTrigger(Event event) {
+        return newTrigger()
+                .withIdentity("startTrigger-" + event.getId(), "event-status")
+                .startAt(Date.from(event.getEventTime().atZone(ZoneId.systemDefault()).toInstant()))
+                .withSchedule(SimpleScheduleBuilder.simpleSchedule().withMisfireHandlingInstructionFireNow())
+                .build();
+    }
+
+    private JobDetail createEndJob(Event event) {
+        return newJob(EventEndJob.class)
+                .withIdentity("endJob-" + event.getId(), "event-status")
+                .usingJobData("eventId", event.getId())
+                .build();
+    }
+
+    private Trigger createEndTrigger(Event event) {
+        return newTrigger()
+                .withIdentity("endTrigger-" + event.getId(), "event-status")
+                .startAt(Date.from(event.getEventEndTime().atZone(ZoneId.systemDefault()).toInstant()))
+                .withSchedule(SimpleScheduleBuilder.simpleSchedule().withMisfireHandlingInstructionFireNow())
+                .build();
+    }
+}

--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/scheduler/EventStatusScheduler.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/scheduler/EventStatusScheduler.java
@@ -83,7 +83,7 @@ public class EventStatusScheduler implements ApplicationRunner {
         log.info("모든 UPCOMING 이벤트 스케줄링 완료.");
     }
 
-    public void schedulerDeleteOpenEvent(Long eventId) {
+    public void deleteOpenEventScheduler(Long eventId) {
         try {
             scheduler.deleteJob(new JobKey("startJob-" + eventId, "event-status"));
 

--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/service/EventAdminService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/service/EventAdminService.java
@@ -1,17 +1,29 @@
 package inu.codin.codinticketingapi.domain.admin.service;
 
-import inu.codin.codinticketingapi.domain.ticketing.dto.response.EventPageResponse;
-import inu.codin.codinticketingapi.security.util.SecurityUtil;
-import inu.codin.codinticketingapi.infra.redis.RedisEventService;
-import inu.codin.codinticketingapi.domain.image.service.ImageService;
-import inu.codin.codinticketingapi.domain.admin.dto.EventCreateRequest;
-import inu.codin.codinticketingapi.domain.admin.dto.EventUpdateRequest;
+import inu.codin.codinticketingapi.domain.admin.dto.request.EventCreateRequest;
+import inu.codin.codinticketingapi.domain.admin.dto.request.EventUpdateRequest;
+import inu.codin.codinticketingapi.domain.admin.dto.response.EventParticipationProfilePageResponse;
+import inu.codin.codinticketingapi.domain.admin.dto.response.EventParticipationProfileResponse;
+import inu.codin.codinticketingapi.domain.admin.dto.response.EventResponse;
+import inu.codin.codinticketingapi.domain.admin.dto.response.EventStockResponse;
 import inu.codin.codinticketingapi.domain.admin.entity.Event;
+import inu.codin.codinticketingapi.domain.admin.entity.EventStatus;
+import inu.codin.codinticketingapi.domain.admin.scheduler.EventStatusScheduler;
+import inu.codin.codinticketingapi.domain.image.service.ImageService;
+import inu.codin.codinticketingapi.domain.ticketing.dto.response.EventPageResponse;
+import inu.codin.codinticketingapi.domain.ticketing.entity.Participation;
+import inu.codin.codinticketingapi.domain.ticketing.entity.Stock;
 import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingErrorCode;
 import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingException;
 import inu.codin.codinticketingapi.domain.ticketing.repository.EventRepository;
+import inu.codin.codinticketingapi.domain.ticketing.repository.ParticipationRepository;
+import inu.codin.codinticketingapi.domain.user.exception.UserErrorCode;
+import inu.codin.codinticketingapi.domain.user.exception.UserException;
 import inu.codin.codinticketingapi.domain.user.service.UserClientService;
+import inu.codin.codinticketingapi.infra.redis.RedisEventService;
+import inu.codin.codinticketingapi.security.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -20,66 +32,59 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class EventAdminService {
 
     private final EventRepository eventRepository;
-    private final UserClientService userClientService;
+    private final ParticipationRepository participationRepository;
+
+    private final static int PAGE_NUMBER = 10;
 
     private final ImageService imageService;
+    private final UserClientService userClientService;
     private final RedisEventService redisEventService;
-//    private final Clock clock;
-
-    public EventPageResponse getEventListByManager(int pageNumber) {
-        String userId = userClientService.fetchUserIdAndUsername(SecurityUtil.getEmail()).userId();
-        Pageable pageable = PageRequest.of(pageNumber, 10, Sort.by("createdAt").descending());
-        return EventPageResponse.of(eventRepository.findByCreatedUserId(userId, pageable));
-    }
-
-    public String getEventPassword(Long eventId) {
-        return eventRepository.findById(eventId)
-                .orElseThrow(() -> new TicketingException(TicketingErrorCode.EVENT_NOT_FOUND))
-                .getEventPassword();
-    }
+    private final EventStatusScheduler eventStatusScheduler;
 
     @Transactional
-    public Event createEvent(EventCreateRequest request, MultipartFile eventImage) {
-        String userId = userClientService.fetchUserIdAndUsername(SecurityUtil.getEmail()).userId();
+    public EventResponse createEvent(EventCreateRequest request, MultipartFile eventImage) {
+        String userId = findAdminUser();
         request.validateEventTimes();
 
         String eventImageUrl = imageService.handleImageUpload(eventImage);
-        Event event = eventRepository.save(request.toEntity(userId, eventImageUrl));
+        Event event = request.toEntity(userId, eventImageUrl);
+        Stock stock = Stock.builder()
+                .event(event)
+                .initialStock(request.getQuantity())
+                .build();
 
-        redisEventService.initializeEvent(event.getId(), event.getQuantity(), event.getEventEndTime());
-        return event;
+        Event savedEvent = eventRepository.save(event);
+        redisEventService.initializeEvent(savedEvent.getId(), stock.getStock(), savedEvent.getEventEndTime());
+        eventStatusScheduler.scheduleCreateOrUpdatedEvent(savedEvent);
+
+        return EventResponse.of(savedEvent);
+    }
+
+    public EventPageResponse getEventListByManager(String status, int pageNumber) {
+        findAdminUser();
+
+        return eventPageResponseWithStatus(status, pageNumber - 1);
     }
 
     @Transactional
-    public Event updateEvent(Long eventId, EventUpdateRequest request, MultipartFile eventImage) {
+    public EventResponse updateEvent(Long eventId, EventUpdateRequest request, MultipartFile eventImage) {
         // 엔티티 조회, 권한 검증
-        Event event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new TicketingException(TicketingErrorCode.EVENT_NOT_FOUND));
-
-        String currentUserId = userClientService
-                .fetchUserIdAndUsername(SecurityUtil.getEmail())
-                .userId();
-
-        if (!event.getUserId().equals(currentUserId) && !SecurityUtil.hasRole("ADMIN")) {
-            throw new TicketingException(TicketingErrorCode.UNAUTHORIZED_EVENT_UPDATE);
-        } else if (event.getEventTime().isBefore(LocalDateTime.now())) {
-            throw new TicketingException(TicketingErrorCode.EVENT_ALREADY_STARTED);
-        }
+        Event event = findEventById(eventId);
+        String currentUserId = findAdminUser();
 
         // 입력값 검증
         request.validateEventTimes();
+        validationEvent(event, currentUserId);
 
         // 수량 변경 대비
-        int oldQuantity = event.getQuantity();
+        int oldQuantity = event.getStock().getStock();
 
         // 이미지 처리
         if (eventImage != null && !eventImage.isEmpty()) {
@@ -89,21 +94,156 @@ public class EventAdminService {
 
         // 엔티티 업데이트
         event.updateFrom(request);
-        Event saved = eventRepository.save(event);
 
         // Redis 동기화 - (수량 변경 시)
-        int newQuantity = saved.getQuantity();
+        int newQuantity = event.getStock().getStock();
+
         if (newQuantity != oldQuantity) {
-            redisEventService.initializeEvent(event.getId(), event.getQuantity(), event.getEventEndTime());
+            redisEventService.initializeEvent(event.getId(), event.getStock().getStock(), event.getEventEndTime());
         }
-        return saved;
+
+        eventStatusScheduler.scheduleCreateOrUpdatedEvent(event);
+
+        return EventResponse.of(event);
     }
 
+    @Transactional
     public void deleteEvent(Long eventId) {
-        Event event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new TicketingException(TicketingErrorCode.EVENT_NOT_FOUND));
+        Event event = findEventById(eventId);
         event.delete();
         redisEventService.deleteEvent(eventId);
-        eventRepository.save(event);
+        eventStatusScheduler.scheduleAllDelete(event);
+    }
+
+    public String getEventPassword(Long eventId) {
+
+        return eventRepository.findById(eventId)
+                .orElseThrow(() -> new TicketingException(TicketingErrorCode.EVENT_NOT_FOUND))
+                .getEventPassword();
+    }
+
+    @Transactional
+    public void closeEvent(Long eventId) {
+        Event findEvent = findEventById(eventId);
+        findEvent.delete();
+        redisEventService.deleteEvent(eventId);
+        eventStatusScheduler.scheduleAllDelete(findEvent);
+    }
+
+//    public String getSignImage(long eventId, String userId) {
+//
+//        return participationRepository.findSignatureImgUrlByEventIdAndUserId(eventId, userId).orElseThrow(() -> new UserException(UserErrorCode.USER_VALIDATION_FAILED));
+//    }
+
+    public EventParticipationProfilePageResponse getParticipationList(Long eventId, int pageNumber) {
+        Pageable pageable = PageRequest.of(pageNumber, 10, Sort.by("ticketNumber").descending());
+
+        Page<Participation> participationList = participationRepository.findAllByEvent_Id(eventId, pageable);
+        List<EventParticipationProfileResponse> profileList = participationList.stream()
+                .map(p -> EventParticipationProfileResponse.of(p.getProfile(), p.getSignatureImgUrl()))
+                .toList();
+
+        int lastPage = getLastPage(participationList.getTotalPages());
+        int nextPage = getNextPage(participationList.hasNext(), participationList.getNumber());
+
+        return new EventParticipationProfilePageResponse(profileList, lastPage, nextPage);
+    }
+
+    @Transactional
+    public boolean changeReceiveStatus(Long eventId, String userId) {
+        Participation findParticipation = getParticipationByEventIdAndUserId(eventId, userId);
+        findParticipation.changeConfirmStatus();
+
+        return true;
+    }
+
+    @Transactional(readOnly = true)
+    public EventStockResponse getStock(Long eventId) {
+        Event findEvent = findEventById(eventId);
+        Stock stock = findEvent.getStock();
+
+        return EventStockResponse.of(stock.getStock());
+    }
+
+    public Boolean cancelTicket(Long eventId, String userId) {
+        Participation findParticipation = getParticipationByEventIdAndUserId(eventId, userId);
+        participationRepository.deleteById(findParticipation.getId());
+
+        return true;
+    }
+
+    @Transactional
+    public Boolean openEvent(Long eventId) {
+        Event findEvent = findEventById(eventId);
+
+        if (findEvent.getEventStatus() == EventStatus.ACTIVE) {
+
+            return true;
+        }
+
+        findEvent.updateStatus(EventStatus.ACTIVE);
+        eventStatusScheduler.schedulerDeleteOpenEvent(eventId);
+
+        return true;
+    }
+
+    private EventPageResponse eventPageResponseWithStatus(String status, int pageNumber) {
+        Pageable pageable = PageRequest.of(pageNumber, PAGE_NUMBER, Sort.by("createdAt").descending());
+
+        return switch (status) {
+            case "all" -> EventPageResponse.of(eventRepository.findAll(pageable));
+            case "upcoming" -> EventPageResponse.of(eventRepository.findAllByEventStatus(EventStatus.UPCOMING, pageable));
+            case "open" -> EventPageResponse.of(eventRepository.findAllByEventStatus(EventStatus.ACTIVE, pageable));
+            case "ended" -> EventPageResponse.of(eventRepository.findAllByEventStatus(EventStatus.ENDED, pageable));
+            default -> throw new TicketingException(TicketingErrorCode.EVENT_NOT_FOUND);
+        };
+    }
+
+    private Event findEventById(Long eventId) {
+
+        return eventRepository.findById(eventId)
+                .orElseThrow(() -> new TicketingException(TicketingErrorCode.EVENT_NOT_FOUND));
+    }
+
+    private String findAdminUser() {
+//        String userId = userClientService
+//                .fetchUserIdAndUsername(SecurityUtil.getEmail())
+//                .userId();
+//
+//        if (userId == null || userId.isBlank()) {
+//            throw new UserException(UserErrorCode.USER_VALIDATION_FAILED);
+//        }
+//
+//        return userId;
+
+        return "1";
+    }
+
+    private void validationEvent(Event event, String userId) {
+        if (!event.getUserId().equals(userId) && !SecurityUtil.hasRole("ADMIN")) {
+            throw new TicketingException(TicketingErrorCode.UNAUTHORIZED_EVENT_UPDATE);
+        }
+
+        if (event.getEventTime().isBefore(LocalDateTime.now())) {
+            throw new TicketingException(TicketingErrorCode.EVENT_ALREADY_STARTED);
+        }
+    }
+
+    private int getLastPage(int totalPage) {
+
+        return totalPage > 0 ? totalPage - 1 : 0;
+    }
+
+    private int getNextPage(boolean hasNext, int page) {
+        if (hasNext) {
+            return page + 1;
+        }
+
+        return -1;
+    }
+
+    private Participation getParticipationByEventIdAndUserId(Long eventId, String userId) {
+
+        return participationRepository.findByEvent_IdAndProfile_UserId(eventId, userId).orElseThrow(() -> new UserException(UserErrorCode.USER_VALIDATION_FAILED));
     }
 }

--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/service/EventAdminService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/service/EventAdminService.java
@@ -41,7 +41,7 @@ public class EventAdminService {
     private final EventRepository eventRepository;
     private final ParticipationRepository participationRepository;
 
-    private final static int PAGE_NUMBER = 10;
+    private final static int PAGE_SIZE = 10;
 
     private final ImageService imageService;
     private final UserClientService userClientService;
@@ -130,11 +130,6 @@ public class EventAdminService {
         eventStatusScheduler.scheduleAllDelete(findEvent);
     }
 
-//    public String getSignImage(long eventId, String userId) {
-//
-//        return participationRepository.findSignatureImgUrlByEventIdAndUserId(eventId, userId).orElseThrow(() -> new UserException(UserErrorCode.USER_VALIDATION_FAILED));
-//    }
-
     public EventParticipationProfilePageResponse getParticipationList(Long eventId, int pageNumber) {
         Pageable pageable = PageRequest.of(pageNumber, 10, Sort.by("ticketNumber").descending());
 
@@ -182,13 +177,13 @@ public class EventAdminService {
         }
 
         findEvent.updateStatus(EventStatus.ACTIVE);
-        eventStatusScheduler.schedulerDeleteOpenEvent(eventId);
+        eventStatusScheduler.deleteOpenEventScheduler(eventId);
 
         return true;
     }
 
     private EventPageResponse eventPageResponseWithStatus(String status, int pageNumber) {
-        Pageable pageable = PageRequest.of(pageNumber, PAGE_NUMBER, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(pageNumber, PAGE_SIZE, Sort.by("createdAt").descending());
 
         return switch (status) {
             case "all" -> EventPageResponse.of(eventRepository.findAll(pageable));
@@ -206,17 +201,15 @@ public class EventAdminService {
     }
 
     private String findAdminUser() {
-//        String userId = userClientService
-//                .fetchUserIdAndUsername(SecurityUtil.getEmail())
-//                .userId();
-//
-//        if (userId == null || userId.isBlank()) {
-//            throw new UserException(UserErrorCode.USER_VALIDATION_FAILED);
-//        }
-//
-//        return userId;
+        String userId = userClientService
+                .fetchUserIdAndUsername(SecurityUtil.getEmail())
+                .userId();
 
-        return "1";
+        if (userId == null || userId.isBlank()) {
+            throw new UserException(UserErrorCode.USER_VALIDATION_FAILED);
+        }
+
+        return userId;
     }
 
     private void validationEvent(Event event, String userId) {

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/EventDetailResponse.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/EventDetailResponse.java
@@ -50,7 +50,7 @@ public class EventDetailResponse {
                 .eventImageUrls(event.getEventImageUrl())
                 .eventTitle(event.getTitle())
                 .locationInfo(event.getLocationInfo())
-                .quantity(event.getQuantity())
+                .quantity(event.getStock().getStock())
                 .target(event.getTarget())
                 .description(event.getDescription())
                 .build();

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/EventResponse.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/EventResponse.java
@@ -38,7 +38,7 @@ public class EventResponse {
                 .eventTitle(event.getTitle())
                 .eventDate(event.getEventTime())
                 .locationInfo(event.getLocationInfo())
-                .quantity(event.getQuantity())
+                .quantity(event.getStock().getStock())
                 .build();
     }
 }

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/entity/Participation.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/entity/Participation.java
@@ -59,6 +59,10 @@ public class Participation extends BaseEntity {
         this.signatureImgUrl = signatureImgUrl;
     }
 
+    public void changeConfirmStatus() {
+        this.confirmed = !confirmed;
+    }
+
     /** 수령 상태 초기화 */
     public void reset() {
         this.confirmed = false;

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/entity/Stock.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/entity/Stock.java
@@ -29,6 +29,7 @@ public class Stock extends BaseEntity {
             name = "event_id", nullable = false, unique = true,
             foreignKey = @ForeignKey(name = "fk_stock_event")
     )
+
     private Event event;
 
     /** 남은 재고 수 */
@@ -43,6 +44,10 @@ public class Stock extends BaseEntity {
     public Stock(Event event, int initialStock) {
         this.event = event;
         this.stock = initialStock;
+
+        if (event != null && event.getStock() != this) {
+            event.setStock(this);
+        }
     }
 
     /** 재고 차감 (원자적 경쟁 방지) */
@@ -50,5 +55,9 @@ public class Stock extends BaseEntity {
         if (stock <= 0) return false;
         stock--;
         return true;
+    }
+
+    public void updateStock(int stock) {
+        this.stock = stock;
     }
 }

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/entity/Stock.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/entity/Stock.java
@@ -36,6 +36,10 @@ public class Stock extends BaseEntity {
     @Column(name = "stock", nullable = false)
     private int stock;
 
+    // 초기 재고 수
+    @Column(name = "initial_stock", nullable = false)
+    private int initialStock;
+
     /** 낙관적 잠금을 위한 버전 */
     @Version
     private Long version;
@@ -44,6 +48,7 @@ public class Stock extends BaseEntity {
     public Stock(Event event, int initialStock) {
         this.event = event;
         this.stock = initialStock;
+        this.initialStock = initialStock;
 
         if (event != null && event.getStock() != this) {
             event.setStock(this);

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/repository/EventRepository.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/repository/EventRepository.java
@@ -1,5 +1,6 @@
 package inu.codin.codinticketingapi.domain.ticketing.repository;
 
+import inu.codin.codinticketingapi.domain.admin.entity.EventStatus;
 import inu.codin.codinticketingapi.domain.ticketing.entity.Campus;
 import inu.codin.codinticketingapi.domain.admin.entity.Event;
 import org.springframework.data.domain.Page;
@@ -9,6 +10,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -26,4 +29,7 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     @Query("SELECT e FROM Event e WHERE e.deletedAt IS NULL AND e.userId = :userId")
     Page<Event> findByCreatedUserId(@Param("userId") String userId, Pageable pageable);
 
+    List<Event> findByEventStatusAndEventTimeAfter(EventStatus eventStatus, LocalDateTime eventTimeAfter);
+
+    Page<Event> findAllByEventStatus(EventStatus eventStatus, Pageable pageable);
 }

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/repository/ParticipationRepository.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/repository/ParticipationRepository.java
@@ -4,53 +4,67 @@ import inu.codin.codinticketingapi.domain.ticketing.dto.response.EventParticipat
 import inu.codin.codinticketingapi.domain.ticketing.entity.Participation;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
 
     @Query("""
-        SELECT new inu.codin.codinticketingapi.domain.ticketing.dto.response.EventParticipationHistoryDto(
-            e.id,
-            e.title,
-            e.eventImageUrl,
-            e.locationInfo,
-            e.eventTime,
-            e.eventEndTime,
-            p.confirmed
-        )
-        FROM Participation p
-        JOIN p.event e
-        WHERE p.profile.userId = :userId
-          AND e.deletedAt IS NULL
-        ORDER BY p.createdAt DESC
-        """)
+            SELECT new inu.codin.codinticketingapi.domain.ticketing.dto.response.EventParticipationHistoryDto(
+                e.id,
+                e.title,
+                e.eventImageUrl,
+                e.locationInfo,
+                e.eventTime,
+                e.eventEndTime,
+                p.confirmed
+            )
+            FROM Participation p
+            JOIN p.event e
+            WHERE p.profile.userId = :userId
+              AND e.deletedAt IS NULL
+            ORDER BY p.createdAt DESC
+            """)
     Page<EventParticipationHistoryDto> findHistoryByUserId(@Param("userId") String userId, Pageable pageable);
 
     @Query("""
-        SELECT new inu.codin.codinticketingapi.domain.ticketing.dto.response.EventParticipationHistoryDto(
-            e.id,
-            e.title,
-            e.eventImageUrl,
-            e.locationInfo,
-            e.eventTime,
-            e.eventEndTime,
-            p.confirmed
-        )
-        FROM Participation p
-        JOIN p.event e
-        WHERE p.profile.userId = :userId
-          AND e.deletedAt IS NULL
-          AND p.canceled = :canceled
-        ORDER BY p.createdAt DESC
-        """)
+            SELECT new inu.codin.codinticketingapi.domain.ticketing.dto.response.EventParticipationHistoryDto(
+                e.id,
+                e.title,
+                e.eventImageUrl,
+                e.locationInfo,
+                e.eventTime,
+                e.eventEndTime,
+                p.confirmed
+            )
+            FROM Participation p
+            JOIN p.event e
+            WHERE p.profile.userId = :userId
+              AND e.deletedAt IS NULL
+              AND p.canceled = :canceled
+            ORDER BY p.createdAt DESC
+            """)
     Page<EventParticipationHistoryDto> findHistoryByUserIdAndCanceled(
             @Param("userId") String userId,
             @Param("canceled") boolean canceled,
             Pageable pageable
     );
 
+    @EntityGraph(attributePaths = {"profile"})
+    Page<Participation> findAllByEvent_Id(Long eventId, Pageable pageable);
+
+    @Query("""
+                SELECT p.signatureImgUrl
+                FROM Participation p
+                WHERE p.event.id = :eventId AND p.profile.userId = :userId
+            """)
+    Optional<String> findSignatureImgUrlByEventIdAndUserId(@Param("eventId") Long eventId, @Param("userId") String userId);
+
+    Optional<Participation> findByEvent_IdAndProfile_UserId(Long eventId, String profileUserId);
 }


### PR DESCRIPTION
이 PR은 이벤트 관리를 위한 관리자 API를 구현하고 이벤트 상태 스케줄러 시스템을 도입합니다. 변경 사항은 이벤트 생명 주기 관리를 위한 관리 기능 추가와 자동화된 이벤트 상태 전환에 중점을 둡니다.

주요 변경 사항:
 - UPCOMING, ACTIVE, ENDED 상태를 포함한 이벤트 상태 관리 기능이 추가되었습니다.
 - 자동 이벤트 상태 전환을 위해 Quartz 기반 스케줄러가 구현되었습니다.
 - 이벤트 엔터티에서 수량(quantity)을 별도의 재고(Stock) 엔터티로 이동하여 이벤트 재고 관리가 리팩토링되었습니다.
 

파일별 변경 내용

| File | Description |
| ---- | ----------- |
| Event.java | 수량 필드 대신 EventStatus enum과 별도의 Stock 엔터티를 사용하도록 리팩토링되었습니다. |
| Stock.java | Event와의 양방향 관계 및 updateStock 메서드가 추가되었습니다. |
| EventAdminService.java | 관리 작업, 이벤트 상태 관리 및 스케줄러 통합을 지원하기 위해 대규모 리팩토링되었습니다. |
| EventStatusScheduler.java | Quartz를 사용하여 자동화된 이벤트 상태 전환을 위한 새로운 스케줄러 컴포넌트입니다. |
| EventStartJob.java/EventEndJob.java | 이벤트 생명 주기 관리를 위한 Quartz 잡(Job) 구현체입니다. |
| ParticipationRepository.java | 관리자 기능 및 EntityGraph 최적화를 위한 쿼리가 추가되었습니다. |
| EventRepository.java | 이벤트 상태 필터링을 지원하는 쿼리가 추가되었습니다. |
| Various DTO classes | 관리자 API 엔드포인트를 위한 새로운 응답 DTO 클래스입니다. |
</details>
