### PR TITLE
refactor: Ticketing 도메인 Service 단위 테스트 작성 및 CampusConverter 오류 수정

### DIFF
--- a/src/main/java/inu/codin/codinticketingapi/common/converter/CampusConverter.java
+++ b/src/main/java/inu/codin/codinticketingapi/common/converter/CampusConverter.java
@@ -1,0 +1,14 @@
+package inu.codin.codinticketingapi.common.converter;
+
+import inu.codin.codinticketingapi.domain.ticketing.entity.Campus;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CampusConverter implements Converter<String, Campus> {
+
+    @Override
+    public Campus convert(String source) {
+        return Campus.fromDescription(source.trim());
+    }
+}

--- a/src/main/java/inu/codin/codinticketingapi/config/SwaggerConfig.java
+++ b/src/main/java/inu/codin/codinticketingapi/config/SwaggerConfig.java
@@ -21,6 +21,9 @@ public class SwaggerConfig {
     @Value("${server.domain}")
     private String BASE_DOMAIN_URL;
 
+    @Value("${server.port}")
+    private String BASE_PORT;
+
     @Bean
     public OpenAPI customOpenAPI() {
         Info info = new Info()
@@ -46,7 +49,7 @@ public class SwaggerConfig {
                 )
                 .servers(List.of(
                         new Server().url(BASE_DOMAIN_URL + "/api/ticketing").description("운영 서버"),
-                        new Server().url("http://localhost:8081").description("로컬 서버")
+                        new Server().url("http://localhost:" + BASE_PORT).description("로컬 서버")
                 ));
     }
 

--- a/src/main/java/inu/codin/codinticketingapi/config/WebConfig.java
+++ b/src/main/java/inu/codin/codinticketingapi/config/WebConfig.java
@@ -1,8 +1,10 @@
 package inu.codin.codinticketingapi.config;
 
+import inu.codin.codinticketingapi.common.converter.CampusConverter;
 import inu.codin.codinticketingapi.common.util.MultipartJackson2HttpMessageConverter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -14,9 +16,16 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final MultipartJackson2HttpMessageConverter multipartJackson2HttpMessageConverter;
 
+    private final CampusConverter campusConverter;
+
     @Override
     public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
         // 컨버터 리스트에 사용자 정의 컨버터 추가
         converters.add(multipartJackson2HttpMessageConverter);
+    }
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(campusConverter);
     }
 }

--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/dto/response/EventResponse.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/dto/response/EventResponse.java
@@ -2,6 +2,7 @@ package inu.codin.codinticketingapi.domain.admin.dto.response;
 
 import inu.codin.codinticketingapi.domain.admin.entity.Event;
 import inu.codin.codinticketingapi.domain.admin.entity.EventStatus;
+import inu.codin.codinticketingapi.domain.ticketing.entity.Campus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,7 +18,7 @@ public class EventResponse {
     @Schema(description = "이벤트 ID", example = "1")
     private Long id;
     @Schema(description = "이벤트가 진행되는 캠퍼스", example = "송도 캠퍼스")
-    private String campus;
+    private Campus campus;
     @Schema(description = "이벤트 시작 시간", example = "2025-07-25T10:00:00")
     private LocalDateTime eventTime;
     @Schema(description = "이벤트 종료 시간", example = "2025-07-25T12:00:00")
@@ -44,7 +45,7 @@ public class EventResponse {
     public static EventResponse of(Event event) {
         return EventResponse.builder()
                 .id(event.getId())
-                .campus(event.getCampus().getDescription())
+                .campus(event.getCampus())
                 .eventTime(event.getEventTime())
                 .eventEndTime(event.getEventEndTime())
                 .eventImageUrl(event.getEventImageUrl())

--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/entity/Event.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/entity/Event.java
@@ -89,7 +89,8 @@ public class Event extends BaseEntity {
     private EventStatus eventStatus;
 
     @Builder
-    public Event(String userId, Campus campus, LocalDateTime eventTime, LocalDateTime eventEndTime, String eventImageUrl, String title, String locationInfo, String target, String description, String inquiryNumber, String promotionLink) {
+    public Event(Long id, String userId, Campus campus, LocalDateTime eventTime, LocalDateTime eventEndTime, String eventImageUrl, String title, String locationInfo, String target, String description, String inquiryNumber, String promotionLink, Stock stock) {
+        this.id = id;
         this.userId = userId;
         this.campus = campus;
         this.eventTime = eventTime;
@@ -103,6 +104,7 @@ public class Event extends BaseEntity {
         this.promotionLink = promotionLink;
         this.eventPassword = generateEventPassword();
         this.eventStatus = EventStatus.UPCOMING;
+        this.stock = stock;
     }
 
     public void setStock(Stock stock) {

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/controller/EventController.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/controller/EventController.java
@@ -35,7 +35,7 @@ public class EventController {
     @Operation(summary = "티켓팅 이벤트 목록 조회 (송도 캠퍼스, 미추홀 캠퍼스)")
     @ApiResponse(responseCode = "200", description = "티켓팅 이벤트 게시물 리스트 조회 성공")
     public ResponseEntity<SingleResponse<EventPageResponse>> getEventList(
-            @Parameter(description = "캠퍼스", example = "송도 캠퍼스, 미추홀 캠퍼스") @RequestParam @Valid Campus campus,
+            @Parameter(description = "캠퍼스", example = "SONGDO_CAMPUS, MICHUHOL_CAMPUS") @RequestParam Campus campus,
             @Parameter(description = "페이지", example = "0") @RequestParam("page") @NotNull int pageNumber
     ) {
         return ResponseEntity.ok(new SingleResponse<>(200, "티켓팅 이벤트 게시물 리스트 조회 성공",

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/EventPageDetailResponse.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/EventPageDetailResponse.java
@@ -2,6 +2,7 @@ package inu.codin.codinticketingapi.domain.ticketing.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import inu.codin.codinticketingapi.domain.admin.entity.Event;
+import inu.codin.codinticketingapi.domain.admin.entity.EventStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -15,7 +16,7 @@ import java.time.LocalDateTime;
 @Setter
 @Builder
 @Schema(description = "티켓팅 이벤트 응답 DTO")
-public class EventResponse {
+public class EventPageDetailResponse {
 
     @Schema(description = "티켓팅 이벤트 ID", example = "111111")
     @NotNull
@@ -41,8 +42,11 @@ public class EventResponse {
     @Schema(description = "이벤트 현재 수량", example = "80")
     private int currentQuantity;
 
-    public static EventResponse of(Event event) {
-        return EventResponse.builder()
+    @Schema(description = "이벤트 상태 enum(UPCOMING, ACTIVE, ENDED)", example = "UPCOMING")
+    private EventStatus eventStatus;
+
+    public static EventPageDetailResponse of(Event event) {
+        return EventPageDetailResponse.builder()
                 .eventId(event.getId())
                 .eventTitle(event.getTitle())
                 .eventImageUrl(event.getEventImageUrl())
@@ -50,6 +54,7 @@ public class EventResponse {
                 .locationInfo(event.getLocationInfo())
                 .quantity(event.getStock().getInitialStock())
                 .currentQuantity(event.getStock().getStock())
+                .eventStatus(event.getEventStatus())
                 .build();
     }
 }

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/EventPageResponse.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/EventPageResponse.java
@@ -16,8 +16,7 @@ import java.util.List;
 public class EventPageResponse {
 
     @Schema(description = "이벤트 목록")
-    private List<EventResponse> eventList = new ArrayList<>();
-
+    private List<EventPageDetailResponse> eventList = new ArrayList<>();
 
     @Schema(description = "마지막 페이지 인덱스", example = "0")
     private long lastPage;
@@ -25,19 +24,19 @@ public class EventPageResponse {
     @Schema(description = "다음 페이지 인덱스", example = "-1")
     private long nextPage;
 
-    public EventPageResponse(List<EventResponse> eventList, long lastPage, long nextPage) {
+    public EventPageResponse(List<EventPageDetailResponse> eventList, long lastPage, long nextPage) {
         this.eventList = eventList;
         this.lastPage = lastPage;
         this.nextPage = nextPage;
     }
 
-    public static EventPageResponse of(List<EventResponse> eventList, long lastPage, long nextPage) {
+    public static EventPageResponse of(List<EventPageDetailResponse> eventList, long lastPage, long nextPage) {
         return new EventPageResponse(eventList, lastPage, nextPage);
     }
 
     public static EventPageResponse of(Page<Event> page) {
-        List<EventResponse> eventList = page.getContent().stream()
-                .map(EventResponse::of)
+        List<EventPageDetailResponse> eventList = page.getContent().stream()
+                .map(EventPageDetailResponse::of)
                 .toList();
 
         return new EventPageResponse(

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/EventResponse.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/EventResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import inu.codin.codinticketingapi.domain.admin.entity.Event;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -17,7 +18,7 @@ import java.time.LocalDateTime;
 public class EventResponse {
 
     @Schema(description = "티켓팅 이벤트 ID", example = "111111")
-    @NotBlank
+    @NotNull
     private Long eventId;
 
     @Schema(description = "이벤트 제목", example = "컴퓨터 공학부 중간고사 간식나눔")

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/entity/Campus.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/entity/Campus.java
@@ -21,7 +21,7 @@ public enum Campus {
                 return campus;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unknown Campus: " + description);
     }
 
     @JsonValue

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/EventService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/EventService.java
@@ -12,6 +12,7 @@ import inu.codin.codinticketingapi.domain.ticketing.repository.ParticipationRepo
 import inu.codin.codinticketingapi.domain.user.service.UserClientService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -29,7 +30,7 @@ public class EventService {
     private final UserClientService userClientService;
 
     @Transactional(readOnly = true)
-    public EventPageResponse getEventList(@Valid Campus campus, int pageNumber) {
+    public EventPageResponse getEventList(@NotNull Campus campus, @PositiveOrZero int pageNumber) {
         Pageable pageable = PageRequest.of(pageNumber, 10, Sort.by("createdAt").descending());
         return EventPageResponse.of(eventRepository.findByCampus(campus, pageable));
     }
@@ -41,14 +42,14 @@ public class EventService {
     }
 
     @Transactional(readOnly = true)
-    public EventParticipationHistoryPageResponse getUserEventList(@NotNull int pageNumber) {
+    public EventParticipationHistoryPageResponse getUserEventList(@PositiveOrZero int pageNumber) {
         String userId = userClientService.fetchUser().getUserId();
         Pageable pageable = PageRequest.of(pageNumber - 1, 10, Sort.by("createdAt").descending());
         return EventParticipationHistoryPageResponse.of(participationRepository.findHistoryByUserId(userId, pageable));
     }
 
     @Transactional(readOnly = true)
-    public EventParticipationHistoryPageResponse getUserEventListByStatus(@NotNull int pageNumber, ParticipationStatus status) {
+    public EventParticipationHistoryPageResponse getUserEventListByStatus(@PositiveOrZero int pageNumber, @NotNull ParticipationStatus status) {
         String userId = userClientService.fetchUser().getUserId();
         Pageable pageable = PageRequest.of(pageNumber - 1, 10, Sort.by("createdAt").descending());
         return EventParticipationHistoryPageResponse.of(participationRepository.findHistoryByUserIdAndCanceled(userId, status, pageable));

--- a/src/main/java/inu/codin/codinticketingapi/domain/user/dto/UserInfoResponse.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/user/dto/UserInfoResponse.java
@@ -1,6 +1,7 @@
 package inu.codin.codinticketingapi.domain.user.dto;
 
 import inu.codin.codinticketingapi.domain.ticketing.entity.Department;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,8 +17,9 @@ public class UserInfoResponse {
     private String profileImageUrl;
     private Department department;
 
-    public UserInfoResponse(String _id, String email, String name, Department department, String studentId) {
-        this._id = _id;
+    @Builder
+    public UserInfoResponse(String userId, String email, String name, Department department, String studentId) {
+        this._id = userId;
         this.email = email;
         this.name = name;
         this.department = department;

--- a/src/main/java/inu/codin/codinticketingapi/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/user/exception/UserErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorCode implements GlobalErrorCode {
 
-    USER_VALIDATION_FAILED(HttpStatus.NOT_FOUND, "User 정보를 가져올 수 없습니다.");
+    USER_VALIDATION_FAILED(HttpStatus.NOT_FOUND, "User 정보를 가져올 수 없습니다."),
+    FETCH_USER_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Server Error: User 정보를 가져올 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/inu/codin/codinticketingapi/domain/user/service/UserClientService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/user/service/UserClientService.java
@@ -2,6 +2,8 @@ package inu.codin.codinticketingapi.domain.user.service;
 
 import inu.codin.codinticketingapi.domain.user.dto.UserApiResponse;
 import inu.codin.codinticketingapi.domain.user.dto.UserInfoResponse;
+import inu.codin.codinticketingapi.domain.user.exception.UserErrorCode;
+import inu.codin.codinticketingapi.domain.user.exception.UserException;
 import inu.codin.codinticketingapi.domain.user.fegin.UserFeignClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +18,9 @@ public class UserClientService {
 
     public UserInfoResponse fetchUser() {
         UserApiResponse userApiResponse = userFeignClient.getUser();
+        if (userApiResponse == null || userApiResponse.getData() == null) {
+            throw new UserException(UserErrorCode.FETCH_USER_FAILED);
+        }
         log.info("[fetchUser] Fetching User Info By User Token, userApiResponse={}", userApiResponse.toString());
         return userApiResponse.getData();
     }

--- a/src/test/java/inu/codin/codinticketingapi/domain/ticketing/service/EventServiceTest.java
+++ b/src/test/java/inu/codin/codinticketingapi/domain/ticketing/service/EventServiceTest.java
@@ -1,0 +1,300 @@
+package inu.codin.codinticketingapi.domain.ticketing.service;
+
+import inu.codin.codinticketingapi.domain.admin.entity.Event;
+import inu.codin.codinticketingapi.domain.ticketing.dto.response.EventDetailResponse;
+import inu.codin.codinticketingapi.domain.ticketing.dto.response.EventPageResponse;
+import inu.codin.codinticketingapi.domain.ticketing.dto.response.EventParticipationHistoryDto;
+import inu.codin.codinticketingapi.domain.ticketing.dto.response.EventParticipationHistoryPageResponse;
+import inu.codin.codinticketingapi.domain.ticketing.entity.Campus;
+import inu.codin.codinticketingapi.domain.ticketing.entity.ParticipationStatus;
+import inu.codin.codinticketingapi.domain.ticketing.entity.Stock;
+import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingErrorCode;
+import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingException;
+import inu.codin.codinticketingapi.domain.ticketing.repository.EventRepository;
+import inu.codin.codinticketingapi.domain.ticketing.repository.ParticipationRepository;
+import inu.codin.codinticketingapi.domain.user.dto.UserInfoResponse;
+import inu.codin.codinticketingapi.domain.user.service.UserClientService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceTest {
+
+    @InjectMocks
+    private EventService eventService;
+
+    @Mock
+    private EventRepository eventRepository;
+    @Mock
+    private ParticipationRepository participationRepository;
+    @Mock
+    private UserClientService userClientService;
+
+    private static final Campus SONGDO = Campus.SONGDO_CAMPUS;
+    private static final Campus MICHUHOL = Campus.MICHUHOL_CAMPUS;
+    private static final int PAGE_SIZE = 10;
+    private static final Sort DESC_SORT = Sort.by("createdAt").descending();
+    private static final String TEST_EVENT_TITLE = "TEST_EVENT_TITLE";
+    private static final String TEST_USER_ID_1 = "user123";
+    private static final String USER_456 = "user456";
+    private static final String TEST_IMAGE_URL = "http://test-image.com";
+    private static final String TEST_LOCATION = "테스트 장소";
+    private static final String TEST_DESCRIPTION = "테스트 이벤트 설명";
+    private static final int INITIAL_STOCK = 100;
+    private static final LocalDateTime START_TIME = LocalDateTime.now().plusDays(1);
+    private static final LocalDateTime END_TIME = LocalDateTime.now().plusDays(1).plusHours(2);
+
+    @Test
+    @DisplayName("이벤트 리스트 반환 - 정상, 페이징 메타 정보 검증")
+    void getEventList_성공() {
+        // given
+        int page = 0;
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE, DESC_SORT);
+        Event mockEvent = createMockEvent(1L, TEST_EVENT_TITLE, SONGDO);
+        Page<Event> mockPage = new PageImpl<>(List.of(mockEvent), pageable, 1);
+
+        given(eventRepository.findByCampus(SONGDO, pageable)).willReturn(mockPage);
+
+        // when
+        EventPageResponse result = eventService.getEventList(SONGDO, page);
+
+        // then
+        assertThat(result.getEventList()).hasSize(1);
+        assertThat(result.getLastPage()).isEqualTo(0);
+        assertThat(result.getNextPage()).isEqualTo(-1);
+        verify(eventRepository).findByCampus(SONGDO, pageable);
+    }
+
+    @Test
+    @DisplayName("이벤트 리스트 반환 - 빈 리스트")
+    void getEventList_빈리스트() {
+        // given
+        int page = 0;
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE, DESC_SORT);
+        Page<Event> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
+
+        given(eventRepository.findByCampus(MICHUHOL, pageable)).willReturn(emptyPage);
+
+        // when
+        EventPageResponse result = eventService.getEventList(MICHUHOL, page);
+
+        // then
+        assertThat(result.getEventList()).isEmpty();
+        assertThat(result.getLastPage()).isEqualTo(-1);
+        assertThat(result.getNextPage()).isEqualTo(-1);
+        verify(eventRepository).findByCampus(MICHUHOL, pageable);
+    }
+
+    @Test
+    @DisplayName("이벤트 리스트 반환 - Campus NULL 일때")
+    void getEventList_campusNull() {
+        // when & then
+        assertThatThrownBy(() -> eventService.getEventList(null, 0))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+
+    @Test
+    @DisplayName("이벤트 리스트 반환 - 페이지 음수 예외")
+    void getEventList_페이지음수예외처리() {
+        // when & then
+        assertThatThrownBy(() -> eventService.getEventList(SONGDO, -1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("이벤트 리스트 반환 – 기본 페이지 크기(10) 로 호출되는지 검증")
+    void getEventList_기본페이지크기() {
+        // given
+        int page = 2;
+        Pageable expected = PageRequest.of(page, 10, Sort.by("createdAt").descending());
+        given(eventRepository.findByCampus(eq(SONGDO), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(), expected, 0));
+
+        // when
+        eventService.getEventList(SONGDO, page);
+
+        // then
+        verify(eventRepository, times(1))
+                .findByCampus(eq(SONGDO), argThat(p -> p.getPageSize() == 10 && p.getPageNumber() == page));
+    }
+
+
+    @Test
+    @DisplayName("이벤트 상세 조회 - 성공")
+    void getEventDetail_성공() {
+        // given
+        Long eventId = 999L;
+        Event mockEvent = createMockEvent(eventId, TEST_EVENT_TITLE, SONGDO);
+        given(eventRepository.findById(eventId)).willReturn(Optional.of(mockEvent));
+
+        // when
+        EventDetailResponse result = eventService.getEventDetail(eventId);
+
+        // then
+        assertThat(result.getEventId()).isEqualTo(eventId);
+        assertThat(result.getEventTitle()).isEqualTo(TEST_EVENT_TITLE);
+        verify(eventRepository).findById(eventId);
+    }
+
+    @Test
+    @DisplayName("이벤트 상세 조회 - 이벤트 없음 예외")
+    void getEventDetail_이벤트존재X() {
+        // given
+        Long eventId = 999L;
+        given(eventRepository.findById(eventId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> eventService.getEventDetail(eventId))
+                .isInstanceOf(TicketingException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TicketingErrorCode.EVENT_NOT_FOUND);
+
+        verify(eventRepository).findById(eventId);
+    }
+
+    @Test
+    @DisplayName("사용자 이벤트 참여 내역 조회 - 정상, 페이징 메타 정보 검증")
+    void getUserEventList_성공() {
+        // given
+        int pageNumber = 1;
+        Pageable pageable = PageRequest.of(0, PAGE_SIZE, DESC_SORT);
+        UserInfoResponse userInfo = UserInfoResponse.builder().userId(TEST_USER_ID_1).build();
+        EventParticipationHistoryDto historyDto = createMockHistoryDto(1L, "TEST HISTORY TITLE", ParticipationStatus.WAITING);
+        Page<EventParticipationHistoryDto> mockPage = new PageImpl<>(List.of(historyDto), pageable, 1);
+
+        given(userClientService.fetchUser()).willReturn(userInfo);
+        given(participationRepository.findHistoryByUserId(TEST_USER_ID_1, pageable)).willReturn(mockPage);
+
+        EventParticipationHistoryPageResponse result = eventService.getUserEventList(pageNumber);
+
+        assertThat(result.getEventList()).hasSize(1);
+        assertThat(result.getLastPage()).isEqualTo(0);
+        assertThat(result.getNextPage()).isEqualTo(-1);
+        verify(userClientService).fetchUser();
+        verify(participationRepository).findHistoryByUserId(TEST_USER_ID_1, pageable);
+    }
+
+    @Test
+    @DisplayName("사용자 이벤트 참여 내역 조회 - 페이지 음수 예외")
+    void getUserEventList_페이지음수() {
+        UserInfoResponse mockUser = UserInfoResponse.builder().userId("testUser").build();
+        given(userClientService.fetchUser()).willReturn(mockUser);
+
+        assertThatThrownBy(() -> eventService.getUserEventList(0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("사용자 이벤트 참여 내역 조회 – 기본 페이지 크기(10)로 호출되는지 검증")
+    void getUserEventList_기본페이지크기() {
+        // given
+        given(userClientService.fetchUser()).willReturn(UserInfoResponse.builder().userId(TEST_USER_ID_1).build());
+        Pageable expected = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+        given(participationRepository.findHistoryByUserId(eq(TEST_USER_ID_1), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(), expected, 0));
+
+        // when
+        eventService.getUserEventList(1);
+
+        // then
+        verify(participationRepository)
+                .findHistoryByUserId(eq(TEST_USER_ID_1), argThat(p -> p.getPageSize() == 10 && p.getPageNumber() == 0));
+    }
+
+    @Test
+    @DisplayName("상태별 사용자 이벤트 참여 내역 조회 - 완료, 취소, 대기")
+    void getUserEventListByStatus_상태별() {
+        int pageNumber = 1;
+        Pageable pageable = PageRequest.of(0, PAGE_SIZE, DESC_SORT);
+        UserInfoResponse userInfo = UserInfoResponse.builder().userId(USER_456).build();
+
+        for (ParticipationStatus status : ParticipationStatus.values()) {
+            // given
+            Page<EventParticipationHistoryDto> mockPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
+            given(userClientService.fetchUser()).willReturn(userInfo);
+            given(participationRepository.findHistoryByUserIdAndCanceled(USER_456, status, pageable)).willReturn(mockPage);
+
+            // when
+            EventParticipationHistoryPageResponse result = eventService.getUserEventListByStatus(pageNumber, status);
+
+            // then
+            assertThat(result.getEventList()).isEmpty();
+            assertThat(result.getLastPage()).isEqualTo(0);
+            assertThat(result.getNextPage()).isEqualTo(-1);
+            verify(userClientService).fetchUser();
+            verify(participationRepository).findHistoryByUserIdAndCanceled(USER_456, status, pageable);
+
+            reset(userClientService, participationRepository);
+        }
+    }
+
+    @Test
+    @DisplayName("상태별 사용자 이벤트 참여 내역 조회 – Status Null")
+    void getUserEventListByStatus_statusNull() {
+        UserInfoResponse mockUser = UserInfoResponse.builder().userId(TEST_USER_ID_1).build();
+        given(userClientService.fetchUser()).willReturn(mockUser);
+
+        assertThatThrownBy(() -> eventService.getUserEventListByStatus(1, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("상태별 사용자 이벤트 참여 내역 조회 – 기본 페이지 크기(10)로 호출되는지 검증")
+    void getUserEventListByStatus_기본페이지크기() {
+        // given
+        ParticipationStatus status = ParticipationStatus.COMPLETED;
+        given(userClientService.fetchUser()).willReturn(UserInfoResponse.builder().userId(TEST_USER_ID_1).build());
+
+        Pageable expected = PageRequest.of(1, 10, Sort.by("createdAt").descending());
+        given(participationRepository.findHistoryByUserIdAndCanceled(eq(TEST_USER_ID_1), eq(status), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(), expected, 0));
+
+        // when
+        eventService.getUserEventListByStatus(2, status);
+
+        // then
+        verify(participationRepository).findHistoryByUserIdAndCanceled(
+                eq(TEST_USER_ID_1),
+                eq(status),
+                argThat(p -> p.getPageSize() == 10 && p.getPageNumber() == 1)
+        );
+    }
+
+    private Event createMockEvent(Long id, String title, Campus campus) {
+        Stock stock = Stock.builder().initialStock(INITIAL_STOCK).build();
+        return Event.builder()
+                .id(id)
+                .title(title)
+                .campus(campus)
+                .eventTime(START_TIME)
+                .eventEndTime(END_TIME)
+                .description(TEST_DESCRIPTION)
+                .locationInfo(TEST_LOCATION)
+                .target("테스트 대상")
+                .eventImageUrl(TEST_IMAGE_URL)
+                .stock(stock)
+                .build();
+    }
+
+    private EventParticipationHistoryDto createMockHistoryDto(Long eventId, String title, ParticipationStatus status) {
+        return new EventParticipationHistoryDto(
+                eventId, title, TEST_IMAGE_URL, TEST_LOCATION, START_TIME, END_TIME, status
+        );
+    }
+}

--- a/src/test/java/inu/codin/codinticketingapi/domain/ticketing/service/ParticipationServiceTest.java
+++ b/src/test/java/inu/codin/codinticketingapi/domain/ticketing/service/ParticipationServiceTest.java
@@ -1,0 +1,192 @@
+package inu.codin.codinticketingapi.domain.ticketing.service;
+
+import inu.codin.codinticketingapi.domain.admin.entity.Event;
+import inu.codin.codinticketingapi.domain.ticketing.dto.response.ParticipationCreateResponse;
+import inu.codin.codinticketingapi.domain.ticketing.entity.Campus;
+import inu.codin.codinticketingapi.domain.ticketing.entity.Participation;
+import inu.codin.codinticketingapi.domain.ticketing.entity.Stock;
+import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingErrorCode;
+import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingException;
+import inu.codin.codinticketingapi.domain.ticketing.repository.EventRepository;
+import inu.codin.codinticketingapi.domain.ticketing.repository.ParticipationRepository;
+import inu.codin.codinticketingapi.domain.user.dto.UserInfoResponse;
+import inu.codin.codinticketingapi.domain.user.service.UserClientService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ParticipationServiceTest {
+
+    @InjectMocks
+    private ParticipationService participationService;
+
+    @Mock
+    private TicketingService ticketingService;
+    @Mock
+    private UserClientService userClientService;
+
+    @Mock
+    private ParticipationRepository participationRepository;
+    @Mock
+    private EventRepository eventRepository;
+
+    // 테스트 상수들
+    private static final Long TEST_EVENT_ID = 1L;
+    private static final Long NON_EXISTENT_EVENT_ID = 999L;
+    private static final String TEST_USER_ID = "testUser";
+    private static final String TEST_USER_NAME = "TEST_USER";
+    private static final String TEST_STUDENT_ID = "202012345";
+    private static final String ADMIN_USER_ID = "adminUser";
+    private static final String TEST_EVENT_TITLE = "TEST_EVENT";
+    private static final String TEST_EVENT_DESCRIPTION = "TEST_EVENT_DESCRIPTION";
+    private static final String TEST_LOCATION = "TEST_LOCATION";
+    private static final String TEST_TARGET = "TEST_TARGET";
+    private static final int INITIAL_STOCK = 100;
+    private static final int CURRENT_STOCK_90 = 90;
+    private static final int CURRENT_STOCK_85 = 85;
+    private static final int EXPECTED_TICKET_NUMBER_10 = 10;
+    private static final int EXPECTED_TICKET_NUMBER_15 = 15;
+
+    @Test
+    @DisplayName("참여자 정보 저장 - 정상")
+    void saveParticipation_성공() {
+        // given
+        UserInfoResponse userInfo = UserInfoResponse.builder()
+                .userId(TEST_USER_ID)
+                .name(TEST_USER_NAME)
+                .studentId(TEST_STUDENT_ID)
+                .build();
+
+        Event mockEvent = createMockEvent(TEST_EVENT_ID, TEST_EVENT_TITLE);
+        Stock mockStock = Stock.builder()
+                .event(mockEvent)
+                .initialStock(INITIAL_STOCK)
+                .build();
+        mockStock.updateStock(CURRENT_STOCK_90);
+
+        Participation savedParticipation = Participation.builder()
+                .event(mockEvent)
+                .ticketNumber(EXPECTED_TICKET_NUMBER_10)
+                .userInfoResponse(userInfo)
+                .build();
+
+        given(userClientService.fetchUser()).willReturn(userInfo);
+        given(eventRepository.findById(TEST_EVENT_ID)).willReturn(Optional.of(mockEvent));
+        given(ticketingService.decrement(TEST_EVENT_ID)).willReturn(mockStock);
+        given(participationRepository.save(any(Participation.class))).willReturn(savedParticipation);
+
+        // when
+        ParticipationCreateResponse result = participationService.saveParticipation(TEST_EVENT_ID);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(userClientService).fetchUser();
+        verify(eventRepository).findById(TEST_EVENT_ID);
+        verify(ticketingService).decrement(TEST_EVENT_ID);
+        verify(participationRepository).save(any(Participation.class));
+    }
+
+    @Test
+    @DisplayName("참여 저장 - 이벤트 없음 예외")
+    void saveParticipation_이벤트존재X() {
+        // given
+        UserInfoResponse userInfo = UserInfoResponse.builder()
+                .userId(TEST_USER_ID)
+                .build();
+
+        given(userClientService.fetchUser()).willReturn(userInfo);
+        given(eventRepository.findById(NON_EXISTENT_EVENT_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> participationService.saveParticipation(NON_EXISTENT_EVENT_ID))
+                .isInstanceOf(TicketingException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TicketingErrorCode.EVENT_NOT_FOUND);
+
+        verify(userClientService).fetchUser();
+        verify(eventRepository).findById(NON_EXISTENT_EVENT_ID);
+        verify(ticketingService, never()).decrement(any());
+        verify(participationRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("참여 저장 - 재고 부족 예외")
+    void saveParticipation_재고부족() {
+        // given
+        UserInfoResponse userInfo = UserInfoResponse.builder()
+                .userId(TEST_USER_ID)
+                .build();
+        Event mockEvent = createMockEvent(TEST_EVENT_ID, TEST_EVENT_TITLE);
+
+        given(userClientService.fetchUser()).willReturn(userInfo);
+        given(eventRepository.findById(TEST_EVENT_ID)).willReturn(Optional.of(mockEvent));
+        given(ticketingService.decrement(TEST_EVENT_ID)).willThrow(new TicketingException(TicketingErrorCode.SOLD_OUT));
+
+        // when & then
+        assertThatThrownBy(() -> participationService.saveParticipation(TEST_EVENT_ID))
+                .isInstanceOf(TicketingException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TicketingErrorCode.SOLD_OUT);
+
+        verify(userClientService).fetchUser();
+        verify(eventRepository).findById(TEST_EVENT_ID);
+        verify(ticketingService).decrement(TEST_EVENT_ID);
+        verify(participationRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("참여 저장 - 티켓 번호 정확성 검증")
+    void saveParticipation_티켓번호검증() {
+        // given
+        UserInfoResponse userInfo = UserInfoResponse.builder()
+                .userId(TEST_USER_ID)
+                .name(TEST_USER_NAME)
+                .studentId(TEST_STUDENT_ID)
+                .build();
+
+        Event mockEvent = createMockEvent(TEST_EVENT_ID, TEST_EVENT_TITLE);
+        Stock mockStock = Stock.builder()
+                .event(mockEvent)
+                .initialStock(INITIAL_STOCK)
+                .build();
+        mockStock.updateStock(CURRENT_STOCK_85);
+
+        given(userClientService.fetchUser()).willReturn(userInfo);
+        given(eventRepository.findById(TEST_EVENT_ID)).willReturn(Optional.of(mockEvent));
+        given(ticketingService.decrement(TEST_EVENT_ID)).willReturn(mockStock);
+        given(participationRepository.save(any(Participation.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        participationService.saveParticipation(TEST_EVENT_ID);
+
+        // then
+        verify(participationRepository).save(argThat(participation ->
+                participation.getTicketNumber().equals(EXPECTED_TICKET_NUMBER_15)
+        ));
+    }
+
+    private Event createMockEvent(Long eventId, String title) {
+        return Event.builder()
+                .id(eventId)
+                .title(title)
+                .userId(ADMIN_USER_ID)
+                .campus(Campus.SONGDO_CAMPUS)
+                .eventTime(LocalDateTime.now().plusDays(1))
+                .eventEndTime(LocalDateTime.now().plusDays(1).plusHours(2))
+                .description(TEST_EVENT_DESCRIPTION)
+                .locationInfo(TEST_LOCATION)
+                .target(TEST_TARGET)
+                .build();
+    }
+}

--- a/src/test/java/inu/codin/codinticketingapi/domain/ticketing/service/TicketingServiceTest.java
+++ b/src/test/java/inu/codin/codinticketingapi/domain/ticketing/service/TicketingServiceTest.java
@@ -1,0 +1,433 @@
+package inu.codin.codinticketingapi.domain.ticketing.service;
+
+import inu.codin.codinticketingapi.domain.admin.entity.Event;
+import inu.codin.codinticketingapi.domain.admin.entity.EventStatus;
+import inu.codin.codinticketingapi.domain.image.service.ImageService;
+import inu.codin.codinticketingapi.domain.ticketing.entity.Campus;
+import inu.codin.codinticketingapi.domain.ticketing.entity.Participation;
+import inu.codin.codinticketingapi.domain.ticketing.entity.ParticipationStatus;
+import inu.codin.codinticketingapi.domain.ticketing.entity.Stock;
+import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingErrorCode;
+import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingException;
+import inu.codin.codinticketingapi.domain.ticketing.repository.EventRepository;
+import inu.codin.codinticketingapi.domain.ticketing.repository.ParticipationRepository;
+import inu.codin.codinticketingapi.domain.ticketing.repository.StockRepository;
+import inu.codin.codinticketingapi.domain.user.dto.UserInfoResponse;
+import inu.codin.codinticketingapi.domain.user.service.UserClientService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TicketingServiceTest {
+
+    @InjectMocks
+    private TicketingService ticketingService;
+
+    @Mock
+    private EventRepository eventRepository;
+    @Mock
+    private ParticipationRepository participationRepository;
+    @Mock
+    private StockRepository stockRepository;
+
+    @Mock
+    private UserClientService userClientService;
+    @Mock
+    private ImageService imageService;
+
+    @Mock
+    private MultipartFile signatureImage;
+
+    // 테스트 상수들
+    private static final Long TEST_EVENT_ID = 1L;
+    private static final Long NON_EXISTENT_EVENT_ID = 999L;
+    private static final String TEST_USER_ID = "testUser";
+    private static final String TEST_USER_NAME = "TEST_USER";
+    private static final String TEST_STUDENT_ID = "202012345";
+    private static final String ADMIN_USER_ID = "adminUser";
+    private static final String TEST_EVENT_TITLE = "TEST_EVENT";
+    private static final String TEST_EVENT_DESCRIPTION = "TEST_EVENT_DESCRIPTION";
+    private static final String TEST_LOCATION = "TEST_LOCATION";
+    private static final String TEST_TARGET = "TEST_TARGET";
+    private static final String CORRECT_PASSWORD = "1234";
+    private static final String WRONG_PASSWORD = "5678";
+    private static final String TEST_SIGNATURE_URL = "http://test-signature.com/image.jpg";
+    private static final int INITIAL_STOCK = 100;
+    private static final int CURRENT_STOCK_50 = 50;
+    private static final int ZERO_STOCK = 0;
+
+    @Test
+    @DisplayName("재고 감소 - 정상")
+    void decrement_성공() {
+        // given
+        Event mockEvent = createMockEvent(TEST_EVENT_ID, TEST_EVENT_TITLE, EventStatus.ACTIVE);
+        Stock mockStock = Stock.builder()
+                .event(mockEvent)
+                .initialStock(INITIAL_STOCK)
+                .build();
+        mockStock.updateStock(CURRENT_STOCK_50);
+
+        given(stockRepository.findByEvent_Id(TEST_EVENT_ID)).willReturn(Optional.of(mockStock));
+
+        // when
+        Stock result = ticketingService.decrement(TEST_EVENT_ID);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getStock()).isEqualTo(CURRENT_STOCK_50 - 1);
+        verify(stockRepository).findByEvent_Id(TEST_EVENT_ID);
+    }
+
+    @Test
+    @DisplayName("재고 감소 - 재고 없음")
+    void decrement_재고없음() {
+        // given
+        given(stockRepository.findByEvent_Id(NON_EXISTENT_EVENT_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> ticketingService.decrement(NON_EXISTENT_EVENT_ID))
+                .isInstanceOf(TicketingException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TicketingErrorCode.STOCK_NOT_FOUND);
+
+        verify(stockRepository).findByEvent_Id(NON_EXISTENT_EVENT_ID);
+    }
+
+    @Test
+    @DisplayName("재고 감소 - 품절")
+    void decrement_품절() {
+        // given
+        Event mockEvent = createMockEvent(TEST_EVENT_ID, TEST_EVENT_TITLE, EventStatus.ACTIVE);
+        Stock mockStock = Stock.builder()
+                .event(mockEvent)
+                .initialStock(INITIAL_STOCK)
+                .build();
+        mockStock.updateStock(ZERO_STOCK);
+
+        given(stockRepository.findByEvent_Id(TEST_EVENT_ID)).willReturn(Optional.of(mockStock));
+
+        // when & then
+        assertThatThrownBy(() -> ticketingService.decrement(TEST_EVENT_ID))
+                .isInstanceOf(TicketingException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TicketingErrorCode.SOLD_OUT);
+
+        verify(stockRepository).findByEvent_Id(TEST_EVENT_ID);
+    }
+
+    @Test
+    @DisplayName("티켓팅 유저 수령 처리 - 정상")
+    void processParticipationSuccess_성공() {
+        // given
+        UserInfoResponse userInfo = createUserInfo(TEST_USER_ID, TEST_USER_NAME);
+        Event mockEvent = createMockEvent(TEST_EVENT_ID, TEST_EVENT_TITLE, EventStatus.ACTIVE);
+        mockEvent = spy(mockEvent);
+        given(mockEvent.getEventPassword()).willReturn(CORRECT_PASSWORD);
+
+        Participation mockParticipation = createMockParticipation(mockEvent, userInfo, ParticipationStatus.WAITING);
+
+        given(userClientService.fetchUser()).willReturn(userInfo);
+        given(eventRepository.findById(TEST_EVENT_ID)).willReturn(Optional.of(mockEvent));
+        given(imageService.handleImageUpload(signatureImage)).willReturn(TEST_SIGNATURE_URL);
+        given(participationRepository.findByEventAndUserId(mockEvent, TEST_USER_ID)).willReturn(Optional.of(mockParticipation));
+
+        // when
+        ticketingService.processParticipationSuccess(TEST_EVENT_ID, CORRECT_PASSWORD, signatureImage);
+
+        // then
+        verify(userClientService).fetchUser();
+        verify(eventRepository).findById(TEST_EVENT_ID);
+        verify(imageService).handleImageUpload(signatureImage);
+        verify(participationRepository).findByEventAndUserId(mockEvent, TEST_USER_ID);
+        verify(mockParticipation).changeStatusCompleted();
+        verify(mockParticipation).setSignatureImgUrl(TEST_SIGNATURE_URL);
+    }
+
+    @Test
+    @DisplayName("티켓팅 유저 수령 처리 - 이벤트 없음")
+    void processParticipationSuccess_이벤트없음() {
+        // given
+        UserInfoResponse userInfo = createUserInfo(TEST_USER_ID, TEST_USER_NAME);
+        given(userClientService.fetchUser()).willReturn(userInfo);
+        given(eventRepository.findById(NON_EXISTENT_EVENT_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> ticketingService.processParticipationSuccess(NON_EXISTENT_EVENT_ID, CORRECT_PASSWORD, signatureImage))
+                .isInstanceOf(TicketingException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TicketingErrorCode.EVENT_NOT_FOUND);
+
+        verify(userClientService).fetchUser();
+        verify(eventRepository).findById(NON_EXISTENT_EVENT_ID);
+        verify(imageService, never()).handleImageUpload(any(MultipartFile.class));
+        verify(participationRepository, never()).findByEventAndUserId(any(), any());
+    }
+
+    @Test
+    @DisplayName("티켓팅 유저 수령 처리 - 이벤트 비활성화")
+    void processParticipationSuccess_이벤트비활성화() {
+        // given
+        UserInfoResponse userInfo = createUserInfo(TEST_USER_ID, TEST_USER_NAME);
+        Event mockEvent = createMockEvent(TEST_EVENT_ID, TEST_EVENT_TITLE, EventStatus.ENDED);
+
+        given(userClientService.fetchUser()).willReturn(userInfo);
+        given(eventRepository.findById(TEST_EVENT_ID)).willReturn(Optional.of(mockEvent));
+
+        // when & then
+        assertThatThrownBy(() -> ticketingService.processParticipationSuccess(TEST_EVENT_ID, CORRECT_PASSWORD, signatureImage))
+                .isInstanceOf(TicketingException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TicketingErrorCode.EVENT_NOT_ACTIVE);
+
+        verify(userClientService).fetchUser();
+        verify(eventRepository).findById(TEST_EVENT_ID);
+        verify(imageService, never()).handleImageUpload(any(MultipartFile.class));
+    }
+
+    @Test
+    @DisplayName("티켓팅 유저 수령 처리 - 잘못된 비밀번호")
+    void processParticipationSuccess_잘못된비밀번호() {
+        // given
+        UserInfoResponse userInfo = createUserInfo(TEST_USER_ID, TEST_USER_NAME);
+        Event mockEvent = createMockEvent(TEST_EVENT_ID, TEST_EVENT_TITLE, EventStatus.ACTIVE);
+        mockEvent = spy(mockEvent);
+        given(mockEvent.getEventPassword()).willReturn(CORRECT_PASSWORD);
+
+        given(userClientService.fetchUser()).willReturn(userInfo);
+        given(eventRepository.findById(TEST_EVENT_ID)).willReturn(Optional.of(mockEvent));
+
+        // when & then
+        assertThatThrownBy(() -> ticketingService.processParticipationSuccess(TEST_EVENT_ID, WRONG_PASSWORD, signatureImage))
+                .isInstanceOf(TicketingException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TicketingErrorCode.PASSWORD_INVALID);
+
+        verify(userClientService).fetchUser();
+        verify(eventRepository).findById(TEST_EVENT_ID);
+        verify(imageService, never()).handleImageUpload(any(MultipartFile.class));
+    }
+
+    @Test
+    @DisplayName("티켓팅 유저 수령 처리 - 참여 정보 없음")
+    void processParticipationSuccess_참여정보없음() {
+        // given
+        UserInfoResponse userInfo = createUserInfo(TEST_USER_ID, TEST_USER_NAME);
+        Event mockEvent = createMockEvent(TEST_EVENT_ID, TEST_EVENT_TITLE, EventStatus.ACTIVE);
+        mockEvent = spy(mockEvent);
+        given(mockEvent.getEventPassword()).willReturn(CORRECT_PASSWORD);
+
+        given(userClientService.fetchUser()).willReturn(userInfo);
+        given(eventRepository.findById(TEST_EVENT_ID)).willReturn(Optional.of(mockEvent));
+        given(imageService.handleImageUpload(signatureImage)).willReturn(TEST_SIGNATURE_URL);
+        given(participationRepository.findByEventAndUserId(mockEvent, TEST_USER_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> ticketingService.processParticipationSuccess(TEST_EVENT_ID, CORRECT_PASSWORD, signatureImage))
+                .isInstanceOf(TicketingException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TicketingErrorCode.PARTICIPATION_NOT_FOUND);
+
+        verify(imageService).handleImageUpload(signatureImage);
+        verify(participationRepository).findByEventAndUserId(mockEvent, TEST_USER_ID);
+    }
+
+    @Test
+    @DisplayName("티켓팅 유저 수령 처리 - 상태 변경 불가")
+    void processParticipationSuccess_상태변경불가() {
+        // given
+        UserInfoResponse userInfo = createUserInfo(TEST_USER_ID, TEST_USER_NAME);
+        Event mockEvent = createMockEvent(TEST_EVENT_ID, TEST_EVENT_TITLE, EventStatus.ACTIVE);
+        mockEvent = spy(mockEvent);
+        given(mockEvent.getEventPassword()).willReturn(CORRECT_PASSWORD);
+
+        Participation mockParticipation = createMockParticipation(mockEvent, userInfo, ParticipationStatus.COMPLETED);
+
+        given(userClientService.fetchUser()).willReturn(userInfo);
+        given(eventRepository.findById(TEST_EVENT_ID)).willReturn(Optional.of(mockEvent));
+        given(imageService.handleImageUpload(signatureImage)).willReturn(TEST_SIGNATURE_URL);
+        given(participationRepository.findByEventAndUserId(mockEvent, TEST_USER_ID)).willReturn(Optional.of(mockParticipation));
+
+        // when & then
+        assertThatThrownBy(() -> ticketingService.processParticipationSuccess(TEST_EVENT_ID, CORRECT_PASSWORD, signatureImage))
+                .isInstanceOf(TicketingException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TicketingErrorCode.CANNOT_CHANGE_STATUS);
+
+        verify(participationRepository).findByEventAndUserId(mockEvent, TEST_USER_ID);
+        verify(mockParticipation, never()).changeStatusCompleted();
+    }
+
+    @Test
+    @DisplayName("티켓팅 참여 취소 - 정상")
+    void changeParticipationStatusCanceled_성공() {
+        // given
+        UserInfoResponse userInfo = createUserInfo(TEST_USER_ID, TEST_USER_NAME);
+        Event mockEvent = createMockEvent(TEST_EVENT_ID, TEST_EVENT_TITLE, EventStatus.ACTIVE);
+        Participation mockParticipation = createMockParticipation(mockEvent, userInfo, ParticipationStatus.WAITING);
+        Stock mockStock = Stock.builder()
+                .event(mockEvent)
+                .initialStock(INITIAL_STOCK)
+                .build();
+
+        given(userClientService.fetchUser()).willReturn(userInfo);
+        given(eventRepository.findById(TEST_EVENT_ID)).willReturn(Optional.of(mockEvent));
+        given(participationRepository.findByEventAndUserId(mockEvent, TEST_USER_ID)).willReturn(Optional.of(mockParticipation));
+        given(stockRepository.findByEvent(mockEvent)).willReturn(Optional.of(mockStock));
+
+        // when
+        ticketingService.changeParticipationStatusCanceled(TEST_EVENT_ID);
+
+        // then
+        verify(userClientService).fetchUser();
+        verify(eventRepository).findById(TEST_EVENT_ID);
+        verify(participationRepository).findByEventAndUserId(mockEvent, TEST_USER_ID);
+        verify(stockRepository).findByEvent(mockEvent);
+        verify(stockRepository).save(mockStock);
+        verify(mockParticipation).changeStatusCanceled();
+    }
+
+    @Test
+    @DisplayName("티켓팅 참여 취소 - 이벤트 없음")
+    void changeParticipationStatusCanceled_이벤트없음() {
+        // given
+        UserInfoResponse userInfo = createUserInfo(TEST_USER_ID, TEST_USER_NAME);
+        given(userClientService.fetchUser()).willReturn(userInfo);
+        given(eventRepository.findById(NON_EXISTENT_EVENT_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> ticketingService.changeParticipationStatusCanceled(NON_EXISTENT_EVENT_ID))
+                .isInstanceOf(TicketingException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TicketingErrorCode.EVENT_NOT_FOUND);
+
+        verify(userClientService).fetchUser();
+        verify(eventRepository).findById(NON_EXISTENT_EVENT_ID);
+        verify(participationRepository, never()).findByEventAndUserId(any(), any());
+    }
+
+    @Test
+    @DisplayName("티켓팅 참여 취소 - 이벤트 시작 전")
+    void changeParticipationStatusCanceled_이벤트비활성화() {
+        // given
+        UserInfoResponse userInfo = createUserInfo(TEST_USER_ID, TEST_USER_NAME);
+        Event mockEvent = createMockEvent(TEST_EVENT_ID, TEST_EVENT_TITLE, EventStatus.UPCOMING);
+
+        given(userClientService.fetchUser()).willReturn(userInfo);
+        given(eventRepository.findById(TEST_EVENT_ID)).willReturn(Optional.of(mockEvent));
+
+        // when & then
+        assertThatThrownBy(() -> ticketingService.changeParticipationStatusCanceled(TEST_EVENT_ID))
+                .isInstanceOf(TicketingException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TicketingErrorCode.EVENT_NOT_ACTIVE);
+
+        verify(userClientService).fetchUser();
+        verify(eventRepository).findById(TEST_EVENT_ID);
+        verify(participationRepository, never()).findByEventAndUserId(any(), any());
+    }
+
+    @Test
+    @DisplayName("티켓팅 참여 취소 - 유저 참여자 정보 없음")
+    void changeParticipationStatusCanceled_참여정보없음() {
+        // given
+        UserInfoResponse userInfo = createUserInfo(TEST_USER_ID, TEST_USER_NAME);
+        Event mockEvent = createMockEvent(TEST_EVENT_ID, TEST_EVENT_TITLE, EventStatus.ACTIVE);
+
+        given(userClientService.fetchUser()).willReturn(userInfo);
+        given(eventRepository.findById(TEST_EVENT_ID)).willReturn(Optional.of(mockEvent));
+        given(participationRepository.findByEventAndUserId(mockEvent, TEST_USER_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> ticketingService.changeParticipationStatusCanceled(TEST_EVENT_ID))
+                .isInstanceOf(TicketingException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TicketingErrorCode.PARTICIPATION_NOT_FOUND);
+
+        verify(participationRepository).findByEventAndUserId(mockEvent, TEST_USER_ID);
+        verify(stockRepository, never()).findByEvent(any());
+    }
+
+    @Test
+    @DisplayName("티켓팅 참여 취소 - 상태 변경 불가")
+    void changeParticipationStatusCanceled_상태변경불가() {
+        // given
+        UserInfoResponse userInfo = createUserInfo(TEST_USER_ID, TEST_USER_NAME);
+        Event mockEvent = createMockEvent(TEST_EVENT_ID, TEST_EVENT_TITLE, EventStatus.ACTIVE);
+        Participation mockParticipation = createMockParticipation(mockEvent, userInfo, ParticipationStatus.COMPLETED);
+
+        given(userClientService.fetchUser()).willReturn(userInfo);
+        given(eventRepository.findById(TEST_EVENT_ID)).willReturn(Optional.of(mockEvent));
+        given(participationRepository.findByEventAndUserId(mockEvent, TEST_USER_ID)).willReturn(Optional.of(mockParticipation));
+
+        // when & then
+        assertThatThrownBy(() -> ticketingService.changeParticipationStatusCanceled(TEST_EVENT_ID))
+                .isInstanceOf(TicketingException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TicketingErrorCode.CANNOT_CHANGE_STATUS);
+
+        verify(participationRepository).findByEventAndUserId(mockEvent, TEST_USER_ID);
+        verify(stockRepository, never()).findByEvent(any());
+        verify(mockParticipation, never()).changeStatusCanceled();
+    }
+
+    @Test
+    @DisplayName("티켓팅 참여 취소 - 재고 정보 없음")
+    void changeParticipationStatusCanceled_재고정보없음() {
+        // given
+        UserInfoResponse userInfo = createUserInfo(TEST_USER_ID, TEST_USER_NAME);
+        Event mockEvent = createMockEvent(TEST_EVENT_ID, TEST_EVENT_TITLE, EventStatus.ACTIVE);
+        Participation mockParticipation = createMockParticipation(mockEvent, userInfo, ParticipationStatus.WAITING);
+
+        given(userClientService.fetchUser()).willReturn(userInfo);
+        given(eventRepository.findById(TEST_EVENT_ID)).willReturn(Optional.of(mockEvent));
+        given(participationRepository.findByEventAndUserId(mockEvent, TEST_USER_ID)).willReturn(Optional.of(mockParticipation));
+        given(stockRepository.findByEvent(mockEvent)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> ticketingService.changeParticipationStatusCanceled(TEST_EVENT_ID))
+                .isInstanceOf(TicketingException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TicketingErrorCode.STOCK_NOT_FOUND);
+
+        verify(stockRepository).findByEvent(mockEvent);
+        verify(mockParticipation, never()).changeStatusCanceled();
+    }
+
+    private UserInfoResponse createUserInfo(String userId, String name) {
+        return UserInfoResponse.builder()
+                .userId(userId)
+                .name(name)
+                .studentId(TEST_STUDENT_ID)
+                .build();
+    }
+
+    private Event createMockEvent(Long eventId, String title, EventStatus status) {
+        Event event = Event.builder()
+                .id(eventId)
+                .title(title)
+                .userId(ADMIN_USER_ID)
+                .campus(Campus.SONGDO_CAMPUS)
+                .eventTime(LocalDateTime.now().plusDays(1))
+                .eventEndTime(LocalDateTime.now().plusDays(1).plusHours(2))
+                .description(TEST_EVENT_DESCRIPTION)
+                .locationInfo(TEST_LOCATION)
+                .target(TEST_TARGET)
+                .build();
+
+        event.updateStatus(status);
+        return event;
+    }
+
+    private Participation createMockParticipation(Event event, UserInfoResponse userInfo, ParticipationStatus status) {
+        Participation participation = spy(Participation.builder()
+                .event(event)
+                .ticketNumber(1)
+                .userInfoResponse(userInfo)
+                .build());
+
+        given(participation.getStatus()).willReturn(status);
+        return participation;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- Ticketing 도메인의 Service 계층에 대한 단위 테스트를 작성했습니다.
- CampusConverter를 추가해 Enum 클래스가 적용되지 않는 오류 수정했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
