### PR TITLE
refactor: 티켓팅 도메인 피드백 적용

### DIFF
--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/EventDetailResponse.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/EventDetailResponse.java
@@ -2,6 +2,7 @@ package inu.codin.codinticketingapi.domain.ticketing.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import inu.codin.codinticketingapi.domain.admin.entity.Event;
+import inu.codin.codinticketingapi.domain.admin.entity.EventStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -46,7 +47,19 @@ public class EventDetailResponse {
     @Schema(description = "이벤트 부가 설명", example = "이벤트 부가 설명문 ~~")
     private String description;
 
-    public static EventDetailResponse of(Event event) {
+    @Schema(description = "이벤트 담당자 문의 번호", example = "010-1234-5678")
+    private String inquiryNumber;
+
+    @Schema(description = "홍보글 링크", example = "www.example.com")
+    private String promotionLink;
+
+    @Schema(description = "이벤트 상태", example = "UPCOMING, ACTIVE, ENDED")
+    private EventStatus eventStatus;
+
+    @Schema(description = "유저 티켓팅 정보 존재 여부", example = "true, false")
+    private boolean isExistParticipationData;
+
+    public static EventDetailResponse of(Event event,  boolean isExistParticipationData) {
         return EventDetailResponse.builder()
                 .eventId(event.getId())
                 .eventTime(event.getEventTime())
@@ -58,6 +71,10 @@ public class EventDetailResponse {
                 .currentQuantity(event.getStock().getStock())
                 .target(event.getTarget())
                 .description(event.getDescription())
+                .inquiryNumber(event.getInquiryNumber())
+                .promotionLink(event.getPromotionLink())
+                .eventStatus(event.getEventStatus())
+                .isExistParticipationData(isExistParticipationData)
                 .build();
     }
 }

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/EventService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/EventService.java
@@ -1,5 +1,6 @@
 package inu.codin.codinticketingapi.domain.ticketing.service;
 
+import inu.codin.codinticketingapi.domain.admin.entity.Event;
 import inu.codin.codinticketingapi.domain.ticketing.dto.response.EventDetailResponse;
 import inu.codin.codinticketingapi.domain.ticketing.dto.response.EventPageResponse;
 import inu.codin.codinticketingapi.domain.ticketing.dto.response.EventParticipationHistoryPageResponse;
@@ -9,6 +10,9 @@ import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingErrorCode
 import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingException;
 import inu.codin.codinticketingapi.domain.ticketing.repository.EventRepository;
 import inu.codin.codinticketingapi.domain.ticketing.repository.ParticipationRepository;
+import inu.codin.codinticketingapi.domain.user.dto.UserInfoResponse;
+import inu.codin.codinticketingapi.domain.user.exception.UserErrorCode;
+import inu.codin.codinticketingapi.domain.user.exception.UserException;
 import inu.codin.codinticketingapi.domain.user.service.UserClientService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -37,8 +41,14 @@ public class EventService {
 
     @Transactional(readOnly = true)
     public EventDetailResponse getEventDetail(Long eventId) {
-        return EventDetailResponse.of(eventRepository.findById(eventId)
-                .orElseThrow(() -> new TicketingException(TicketingErrorCode.EVENT_NOT_FOUND)));
+        UserInfoResponse userInfoResponse = userClientService.fetchUser();
+        // 유저 티켓팅 정보가 존재하는지 검증
+        boolean isExistParticipationData = userInfoResponse.getName() != null && userInfoResponse.getDepartment() != null && userInfoResponse.getStudentId() != null;
+
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new TicketingException(TicketingErrorCode.EVENT_NOT_FOUND));
+
+        return EventDetailResponse.of(event, isExistParticipationData);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/ParticipationService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/ParticipationService.java
@@ -11,6 +11,8 @@ import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingException
 import inu.codin.codinticketingapi.domain.ticketing.repository.EventRepository;
 import inu.codin.codinticketingapi.domain.ticketing.repository.ParticipationRepository;
 import inu.codin.codinticketingapi.domain.user.dto.UserInfoResponse;
+import inu.codin.codinticketingapi.domain.user.exception.UserErrorCode;
+import inu.codin.codinticketingapi.domain.user.exception.UserException;
 import inu.codin.codinticketingapi.domain.user.service.UserClientService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -42,6 +44,11 @@ public class ParticipationService {
     @Transactional
     public ParticipationCreateResponse saveParticipation(Long eventId) {
         UserInfoResponse userInfoResponse = userClientService.fetchUser();
+        // 유저 티켓팅 정보가 존재하는지 검증
+        if (userInfoResponse.getName() == null || userInfoResponse.getDepartment() == null || userInfoResponse.getStudentId() == null) {
+            throw new UserException(UserErrorCode.NOT_EXIST_PARTICIPATION_DATA);
+        }
+
         Event event = eventRepository.findById(eventId).orElseThrow(() -> new TicketingException(TicketingErrorCode.EVENT_NOT_FOUND));
         Stock stock = ticketingService.decrement(eventId);
 

--- a/src/main/java/inu/codin/codinticketingapi/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/user/exception/UserErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements GlobalErrorCode {
 
     USER_VALIDATION_FAILED(HttpStatus.NOT_FOUND, "User 정보를 가져올 수 없습니다."),
+    NOT_EXIST_PARTICIPATION_DATA(HttpStatus.BAD_REQUEST, "유저 참여자 정보가 존재하지 않습니다."),
     FETCH_USER_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Server Error: User 정보를 가져올 수 없습니다.");
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

close #25

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- EventDetailResponse: 데이터 반환 멤버 추가 (참여 정보 존재여부)
- getEventDetail: 티켓팅 참여 정보 검증로직 추가
- saveParticipation: 유저 티켓팅 정보가 존재하는지 검증
- UserErrorCode: NOT_EXIST_PARTICIPATION_DATA 추가

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 이벤트 상세 정보에 문의 번호, 프로모션 링크, 이벤트 상태, 참여 정보 존재 여부가 추가되었습니다.
  * 이벤트 상세 조회 시 사용자의 참여자 정보(이름, 학과, 학번) 존재 여부가 함께 제공됩니다.

* **버그 수정**
  * 참여 신청 시 사용자 정보(이름, 학과, 학번)가 누락된 경우 참여가 제한되고, 관련 오류 메시지가 안내됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->