### PR TITLE
refactor: Sse 모듈 기능 개선 #35

### DIFF
--- a/codin-ticketing-sse/build.gradle
+++ b/codin-ticketing-sse/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mockito:mockito-core:5.7.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.7.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/codin-ticketing-sse/build.gradle
+++ b/codin-ticketing-sse/build.gradle
@@ -36,8 +36,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.mockito:mockito-core:5.7.0'
-    testImplementation 'org.mockito:mockito-junit-jupiter:5.7.0'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/CodinTicketingSseApplication.java
+++ b/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/CodinTicketingSseApplication.java
@@ -1,9 +1,12 @@
 package inu.codin.codinticketingsse;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class CodinTicketingSseApplication {
 
     public static void main(String[] args) {

--- a/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/config/SecurityConfig.java
+++ b/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
                         // 테스트 API 경로 - @PreAuthorize로 권한 제어
                         .requestMatchers("/v3/api/test**").permitAll()
                         // Sse 구독 엔드포인트 허용 (없으면 AccessDenied 오류 생김)
-                        .requestMatchers("subscribe/**").permitAll()
+                        .requestMatchers("/subscribe/**").permitAll()
                         // 모든 요청은 인증 필요, 단 특정 경로는 예외
                         .requestMatchers("/public/**").permitAll() // Public endpoints
                         .anyRequest().hasAnyRole("USER", "MANAGER", "ADMIN")

--- a/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/config/SecurityConfig.java
+++ b/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/config/SecurityConfig.java
@@ -42,6 +42,8 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**").permitAll()
                         // 테스트 API 경로 - @PreAuthorize로 권한 제어
                         .requestMatchers("/v3/api/test**").permitAll()
+                        // Sse 구독 엔드포인트 허용 (없으면 AccessDenied 오류 생김)
+                        .requestMatchers("subscribe/**").permitAll()
                         // 모든 요청은 인증 필요, 단 특정 경로는 예외
                         .requestMatchers("/public/**").permitAll() // Public endpoints
                         .anyRequest().hasAnyRole("USER", "MANAGER", "ADMIN")

--- a/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/config/SwaggerConfig.java
+++ b/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/config/SwaggerConfig.java
@@ -20,6 +20,8 @@ public class SwaggerConfig {
 
     @Value("${server.domain}")
     private String BASE_DOMAIN_URL;
+    @Value("${server.port}")
+    private String SERVER_PORT;
 
     @Bean
     public OpenAPI customOpenAPI() {
@@ -46,7 +48,7 @@ public class SwaggerConfig {
                 )
                 .servers(List.of(
                         new Server().url(BASE_DOMAIN_URL + "/api/ticketing/sse").description("운영 서버"),
-                        new Server().url("http://localhost:8082").description("로컬 서버")
+                        new Server().url("http://localhost:" + SERVER_PORT).description("로컬 서버")
                 ));
     }
 

--- a/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/config/RedisStreamListenerConfig.java
+++ b/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/config/RedisStreamListenerConfig.java
@@ -5,6 +5,7 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.stream.Consumer;
@@ -42,8 +43,11 @@ public class RedisStreamListenerConfig {
         } catch (Exception e) {
             log.info("Redis Stream 그룹이 이미 존재, group:{}, message:{}", GROUP_NAME, e.getMessage());
         }
+    }
 
-        // ListenerContainer 옵션 설정
+    /** StreamMessageListenerContainer 빈 등록 및 시작 */
+    @Bean
+    public StreamMessageListenerContainer<String, MapRecord<String, String, String>> streamContainer() {
         StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> options =
                 StreamMessageListenerContainerOptions.builder()
                     .pollTimeout(Duration.ofMillis(200)) // 저지연성 우선
@@ -62,5 +66,6 @@ public class RedisStreamListenerConfig {
         // 컨테이너 시작
         container.start();
         log.info("Redis Stream Listener 컨테이너 시작, key:{}", STREAM_KEY);
+        return container;
     }
 }

--- a/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/controller/SseController.java
+++ b/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/controller/SseController.java
@@ -1,5 +1,6 @@
 package inu.codin.codinticketingsse.sse.controller;
 
+import inu.codin.codinticketingsse.security.util.SecurityUtil;
 import inu.codin.codinticketingsse.sse.dto.EventStockStream;
 import inu.codin.codinticketingsse.sse.service.SseService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,7 +26,16 @@ public class SseController {
     public ResponseEntity<SseEmitter> subscribeEvent(
             @Parameter(description = "구독한 이벤트 ID", example = "1111") @PathVariable Long eventId
     ) {
-        return ResponseEntity.ok(sseService.subscribeEventStock(eventId));
+        return ResponseEntity.ok(sseService.subscribeEventStock(eventId, SecurityUtil.getUserId()));
+    }
+
+    @DeleteMapping("/{eventId}/disconnect")
+    @Operation(summary = "이벤트 SSE 연결 해제")
+    public ResponseEntity<?> disconnect(
+            @Parameter(description = "구독 취소할 이벤트 ID", example = "1111") @PathVariable Long eventId
+    ) {
+        sseService.closeConnection(eventId, SecurityUtil.getUserId());
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping(value = "/{eventId}")

--- a/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/controller/SseController.java
+++ b/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/controller/SseController.java
@@ -26,7 +26,10 @@ public class SseController {
     public ResponseEntity<SseEmitter> subscribeEvent(
             @Parameter(description = "구독한 이벤트 ID", example = "1111") @PathVariable Long eventId
     ) {
-        return ResponseEntity.ok(sseService.subscribeEventStock(eventId, SecurityUtil.getUserId()));
+        SseEmitter emitter = sseService.subscribeEventStock(eventId, SecurityUtil.getUserId());
+        return ResponseEntity.ok()
+                .header("X-Accel-Buffering", "no")
+                .body(emitter);
     }
 
     @DeleteMapping("disconnect/{eventId}")

--- a/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/controller/SseController.java
+++ b/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/controller/SseController.java
@@ -21,7 +21,7 @@ public class SseController {
         this.sseService = sseService;
     }
 
-    @GetMapping(value = "/{eventId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @GetMapping(value = "subscribe/{eventId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     @Operation(summary = "이벤트 재고상태 SSE 구독")
     public ResponseEntity<SseEmitter> subscribeEvent(
             @Parameter(description = "구독한 이벤트 ID", example = "1111") @PathVariable Long eventId
@@ -29,7 +29,7 @@ public class SseController {
         return ResponseEntity.ok(sseService.subscribeEventStock(eventId, SecurityUtil.getUserId()));
     }
 
-    @DeleteMapping("/{eventId}/disconnect")
+    @DeleteMapping("disconnect/{eventId}")
     @Operation(summary = "이벤트 SSE 연결 해제")
     public ResponseEntity<?> disconnect(
             @Parameter(description = "구독 취소할 이벤트 ID", example = "1111") @PathVariable Long eventId
@@ -38,7 +38,7 @@ public class SseController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping(value = "/{eventId}")
+    @PostMapping(value = "send/{eventId}")
     @Operation(summary = "[테스트] 재고상태 SSE 전송 - MANAGER, ADMIN")
     public ResponseEntity<?> sendQuantityUpdateEvent(
             @Parameter(description = "구독한 이벤트 ID", example = "1111") @PathVariable Long eventId,

--- a/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/dto/SseEmitterTimeoutEvent.java
+++ b/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/dto/SseEmitterTimeoutEvent.java
@@ -1,0 +1,20 @@
+package inu.codin.codinticketingsse.sse.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class SseEmitterTimeoutEvent {
+
+    private final String emitterId;
+    private final Long eventId;
+    private final String userId;
+    private final LocalDateTime timestamp;
+
+    public static SseEmitterTimeoutEvent of(String emitterId, Long eventId, String userId) {
+        return new SseEmitterTimeoutEvent(emitterId, eventId, userId, LocalDateTime.now());
+    }
+}

--- a/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/monitor/SseConnectionMonitor.java
+++ b/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/monitor/SseConnectionMonitor.java
@@ -1,0 +1,68 @@
+package inu.codin.codinticketingsse.sse.monitor;
+
+import inu.codin.codinticketingsse.sse.dto.SseEmitterTimeoutEvent;
+import inu.codin.codinticketingsse.sse.repository.SseEmitterRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SseConnectionMonitor {
+
+    private final SseEmitterRepository sseEmitterRepository;
+
+    @EventListener
+    @Async
+    public void handleEmitterTimeout(SseEmitterTimeoutEvent event) {
+        log.info("SSE 연결 Timeout: emitterId={}, eventId={}, userId={}, timestamp={}",
+                event.getEmitterId(), event.getEventId(), event.getUserId(), event.getTimestamp());
+
+        // 타임아웃된 연결에 대한 추가 정리 작업
+        try {
+            sseEmitterRepository.removeEmitter(event.getEventId(), event.getUserId());
+            log.info("타임아웃된 SSE 연결 정리 완료: eventId={}, userId={}",
+                    event.getEventId(), event.getUserId());
+        } catch (Exception e) {
+            log.error("타임아웃된 SSE 연결 정리 실패: eventId={}, userId={}, error={}",
+                    event.getEventId(), event.getUserId(), e.getMessage());
+        }
+    }
+
+    @Scheduled(fixedRate = 60000) // 1분마다 실행
+    public void logConnectionStats() {
+        int activeConnections = sseEmitterRepository.getActiveConnectionCount();
+        log.info("활성 SSE 연결 수: {}", activeConnections);
+
+        if (activeConnections > 1000) {
+            log.warn("SSE 연결 수가 임계값을 초과했습니다: {}", activeConnections);
+        }
+    }
+
+    @Scheduled(fixedRate = 300000) // 5분마다 실행
+    public void cleanupDeadConnections() {
+        log.info("SSE 연결 상태 점검 시작");
+
+        sseEmitterRepository.getAllEmitters().forEach((key, emitter) -> {
+            try {
+                // ping 테스트
+                emitter.send("ping");
+            } catch (Exception e) {
+                // 응답하지 없는 연결 정리
+                String[] keyParts = key.split(":");
+                if (keyParts.length == 2) {
+                    Long eventId = Long.valueOf(keyParts[0]);
+                    String userId = keyParts[1];
+                    sseEmitterRepository.removeEmitter(eventId, userId);
+                    log.info("비활성 SSE 연결 정리: key={}", key);
+                }
+            }
+        });
+
+        log.info("SSE 연결 상태 점검 완료");
+    }
+}

--- a/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/repository/SseEmitterRepository.java
+++ b/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/repository/SseEmitterRepository.java
@@ -3,12 +3,14 @@ package inu.codin.codinticketingsse.sse.repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 public interface SseEmitterRepository {
-    SseEmitter saveEmitter(Long eventId, SseEmitter emitter);
+    SseEmitter saveEmitter(Long eventId, String userId, SseEmitter emitter);
+    SseEmitter findEmitter(Long eventId, String userId);
     List<SseEmitter> findAll(Long eventId);
     void deleteByEventIdAndEmitter(Long eventId, SseEmitter emitter);
-
-    void addEvent(Long evenId);
-    void removeEvent(Long evenId);
+    void removeEmitter(Long eventId, String userId);
+    ConcurrentHashMap<String, SseEmitter> getAllEmitters();
+    int getActiveConnectionCount();
 }

--- a/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/repository/SseEmitterRepositoryImpl.java
+++ b/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/repository/SseEmitterRepositoryImpl.java
@@ -3,42 +3,92 @@ package inu.codin.codinticketingsse.sse.repository;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 @Repository
 public class SseEmitterRepositoryImpl implements SseEmitterRepository {
 
-    private final ConcurrentHashMap<Long, CopyOnWriteArrayList<SseEmitter>> emitterMap = new ConcurrentHashMap<>();;
+    // 사용자별 + 이벤트별 Emitter 관리 <Key, SseEmitter>
+    private final ConcurrentHashMap<String, SseEmitter> emitterMap = new ConcurrentHashMap<>();
+    // 이벤트별 구독자 키 관리 <eventId, Set<Key>>
+    private final ConcurrentHashMap<Long, Set<String>> eventSubscribers = new ConcurrentHashMap<>();
 
     @Override
-    public SseEmitter saveEmitter(Long eventId, SseEmitter emitter) {
-        emitterMap.computeIfAbsent(eventId, id -> new CopyOnWriteArrayList<>())
-                .add(emitter);
+    public SseEmitter saveEmitter(Long eventId, String userId, SseEmitter emitter) {
+        String key = generateKey(eventId, userId);
+        emitterMap.put(key, emitter);
+        eventSubscribers.computeIfAbsent(eventId, k -> ConcurrentHashMap.newKeySet()).add(key);
         return emitter;
     }
 
     @Override
+    public SseEmitter findEmitter(Long eventId, String userId) {
+        String key = generateKey(eventId, userId);
+        return emitterMap.get(key);
+    }
+
+    @Override
     public List<SseEmitter> findAll(Long eventId) {
-        return emitterMap.getOrDefault(eventId, new CopyOnWriteArrayList<>());
+        Set<String> keys = eventSubscribers.get(eventId);
+        if (keys == null || keys.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        return keys.stream()
+                .map(emitterMap::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     @Override
     public void deleteByEventIdAndEmitter(Long eventId, SseEmitter emitter) {
-        emitterMap.computeIfPresent(eventId, (id, list) -> {
-            list.remove(emitter);
-            return list.isEmpty() ? null : list;
-        });
+        Set<String> keys = eventSubscribers.get(eventId);
+        if (keys != null) {
+            keys.removeIf(key -> {
+                SseEmitter stored = emitterMap.get(key);
+                if (stored == emitter) {
+                    emitterMap.remove(key);
+                    return true;
+                }
+                return false;
+            });
+
+            if (keys.isEmpty()) {
+                eventSubscribers.remove(eventId);
+            }
+        }
     }
 
     @Override
-    public void addEvent(Long evenId) {
-        emitterMap.putIfAbsent(evenId, new CopyOnWriteArrayList<>());
+    public void removeEmitter(Long eventId, String userId) {
+        String key = generateKey(eventId, userId);
+        emitterMap.remove(key);
+
+        Set<String> keys = eventSubscribers.get(eventId);
+        if (keys != null) {
+            keys.remove(key);
+            if (keys.isEmpty()) {
+                eventSubscribers.remove(eventId);
+            }
+        }
     }
 
     @Override
-    public void removeEvent(Long evenId) {
-        emitterMap.remove(evenId);
+    public ConcurrentHashMap<String, SseEmitter> getAllEmitters() {
+        return new ConcurrentHashMap<>(emitterMap);
+    }
+
+    @Override
+    public int getActiveConnectionCount() {
+        return emitterMap.size();
+    }
+
+    private String generateKey(Long eventId, String userId) {
+        return eventId + ":" + userId;
     }
 }

--- a/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/service/SseService.java
+++ b/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/service/SseService.java
@@ -5,8 +5,7 @@ import inu.codin.codinticketingsse.sse.dto.SseEmitterTimeoutEvent;
 import inu.codin.codinticketingsse.sse.dto.SseStockResponse;
 import inu.codin.codinticketingsse.sse.repository.SseEmitterRepository;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -17,10 +16,10 @@ import java.io.IOException;
 import java.util.List;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class SseService {
 
-    private final Logger log = LoggerFactory.getLogger(SseService.class);
     private final Long DEFAULT_TIMEOUT = 10 * 60 * 1000L; // 10분
 
     private final SseEmitterRepository sseEmitterRepository;

--- a/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/service/SseService.java
+++ b/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/service/SseService.java
@@ -1,6 +1,5 @@
 package inu.codin.codinticketingsse.sse.service;
 
-import inu.codin.codinticketingsse.security.util.SecurityUtil;
 import inu.codin.codinticketingsse.sse.dto.EventStockStream;
 import inu.codin.codinticketingsse.sse.dto.SseEmitterTimeoutEvent;
 import inu.codin.codinticketingsse.sse.dto.SseStockResponse;
@@ -87,7 +86,11 @@ public class SseService {
      * Scheduled 30초
      */
     @Scheduled(fixedRate = 30000)
-    public void sendHeartbeat() {
+    public void deleteDeadConnections() {
+        sendHeartbeatAllEmitters();
+    }
+
+    public void sendHeartbeatAllEmitters() {
         sseEmitterRepository.getAllEmitters().forEach((key, emitter) -> {
             try {
                 emitter.send(SseEmitter.event()

--- a/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/service/SseService.java
+++ b/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/sse/service/SseService.java
@@ -1,11 +1,16 @@
 package inu.codin.codinticketingsse.sse.service;
 
+import inu.codin.codinticketingsse.security.util.SecurityUtil;
 import inu.codin.codinticketingsse.sse.dto.EventStockStream;
+import inu.codin.codinticketingsse.sse.dto.SseEmitterTimeoutEvent;
 import inu.codin.codinticketingsse.sse.dto.SseStockResponse;
 import inu.codin.codinticketingsse.sse.repository.SseEmitterRepository;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -13,29 +18,35 @@ import java.io.IOException;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class SseService {
 
     private final Logger log = LoggerFactory.getLogger(SseService.class);
-    private final Long DEFAULT_TIMEOUT = 30 * 60 * 1000L; // 30분
-
-    // todo : 이벤트 상황이 아닐 때에는 HearBeat 기능 추가
+    private final Long DEFAULT_TIMEOUT = 10 * 60 * 1000L; // 10분
 
     private final SseEmitterRepository sseEmitterRepository;
-
-    public SseService(SseEmitterRepository sseEmitterRepository) {
-        this.sseEmitterRepository = sseEmitterRepository;
-    }
+    private final ApplicationEventPublisher eventPublisher;
 
     /** SSE 구독 시작 */
-    public SseEmitter subscribeEventStock(Long eventId) {
-        SseEmitter emitter = sseEmitterRepository.saveEmitter(eventId,  new SseEmitter(DEFAULT_TIMEOUT));
-        log.info("SSE 구독 시작, event : {}, emitter : {}", eventId, emitter.toString());
+    public SseEmitter subscribeEventStock(Long eventId, String userId) {
+        SseEmitter emitter = sseEmitterRepository.saveEmitter(eventId, userId, new SseEmitter(DEFAULT_TIMEOUT));
+        log.info("SSE 구독 시작, event : {}, userId : {}, emitter : {}", eventId, userId, emitter.toString());
 
-        emitter.onCompletion(() -> sseEmitterRepository.deleteByEventIdAndEmitter(eventId, emitter));
-        emitter.onTimeout(() -> sseEmitterRepository.deleteByEventIdAndEmitter(eventId, emitter));
+        emitter.onCompletion(() -> {
+            sseEmitterRepository.deleteByEventIdAndEmitter(eventId, emitter);
+            log.info("SSE 연결 완료 - eventId: {}, userId: {}", eventId, userId);
+        });
+
+        emitter.onTimeout(() -> {
+            sseEmitterRepository.deleteByEventIdAndEmitter(eventId, emitter);
+            eventPublisher.publishEvent(SseEmitterTimeoutEvent.of(
+                    generateKey(eventId, userId), eventId, userId));
+            log.info("SSE 연결 타임아웃 - eventId: {}, userId: {}", eventId, userId);
+        });
+
         emitter.onError(e -> {
-                    log.warn("Emitter onError 처리 : {}", e.getMessage());
-                    sseEmitterRepository.deleteByEventIdAndEmitter(eventId, emitter);
+            log.warn("Emitter onError 처리 - eventId: {}, userId: {}, error: {}", eventId, userId, e.getMessage());
+            sseEmitterRepository.deleteByEventIdAndEmitter(eventId, emitter);
         });
 
         sendAsyncToClient(emitter, "Init Subscribed to event : " + eventId, "ticketing-stock-sse");
@@ -69,5 +80,50 @@ public class SseService {
             // onError 콜백 실행
             emitter.completeWithError(ex);
         }
+    }
+
+    /**
+     * HeartBeat를 연결 중인 모든 Emitter에 전송하여 비활성 연결 정리
+     * Scheduled 30초
+     */
+    @Scheduled(fixedRate = 30000)
+    public void sendHeartbeat() {
+        sseEmitterRepository.getAllEmitters().forEach((key, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("heartbeat")
+                        .data("ping"));
+            } catch (Exception e) {
+                // 연결이 끊어진 Emitter 제거
+                String[] keyParts = key.split(":");
+                if (keyParts.length == 2) {
+                    Long eventId = Long.valueOf(keyParts[0]);
+                    String userId = keyParts[1];
+                    sseEmitterRepository.removeEmitter(eventId, userId);
+                    log.info("HeartBeat 실패로 SSE 연결 제거: key={}", key);
+                }
+            }
+        });
+    }
+
+    /**
+     * SSE Emitter 연결 종료
+     * @param eventId connection 유지 중인 event
+     * @param userId String userId (MongoDB)
+     */
+    public void closeConnection(Long eventId, String userId) {
+        SseEmitter emitter = sseEmitterRepository.findEmitter(eventId, userId);
+        if (emitter != null) {
+            emitter.complete(); // 정상적으로 연결 종료
+            sseEmitterRepository.removeEmitter(eventId, userId);
+            log.info("SSE 연결 수동 종료 - eventId: {}, userId: {}", eventId, userId);
+        }
+    }
+
+    /**
+     * 키 생성 헬퍼 메서드
+     */
+    private String generateKey(Long eventId, String userId) {
+        return eventId + ":" + userId;
     }
 }

--- a/codin-ticketing-sse/src/main/resources/application.yml
+++ b/codin-ticketing-sse/src/main/resources/application.yml
@@ -3,6 +3,9 @@ spring:
     name: codin-ticketing-sse
   jwt:
     secret: ${SPRING_JWT_SECRET}
+  mvc:
+    async:
+      request-timeout: 0
   config:
     import: optional:file:./.env[.properties], optional:file:./.env.local[.properties]
   # Redis Configuration
@@ -22,10 +25,6 @@ redis:
       consumer: ${STOCK_REDIS_STREAM_CONSUMER:event-stock-consumer}
 
 server:
-  tomcat:
-    connection-timeout: 30m
-    keep-alive-timeout: 30m
-    max-keep-alive-requests: 1000
   domain: https://codin.inu.ac.kr
   forward-headers-strategy: framework
   port: ${SSE_SERVER_PORT:8084}

--- a/codin-ticketing-sse/src/main/resources/application.yml
+++ b/codin-ticketing-sse/src/main/resources/application.yml
@@ -22,9 +22,13 @@ redis:
       consumer: ${STOCK_REDIS_STREAM_CONSUMER:event-stock-consumer}
 
 server:
+  tomcat:
+    connection-timeout: 30m
+    keep-alive-timeout: 30m
+    max-keep-alive-requests: 1000
   domain: https://codin.inu.ac.kr
   forward-headers-strategy: framework
-  port: ${SSE_SERVER_PORT:8082}
+  port: ${SSE_SERVER_PORT:8084}
 
 # Swagger SpringDoc Configuration
 springdoc:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

#35

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* **신규 기능**
  * SSE(서버 전송 이벤트) 연결 모니터링 기능이 추가되어, 연결 상태를 주기적으로 점검하고 비정상 연결을 정리합니다.
  * 사용자별 이벤트 구독 및 연결 해제(Disconnect) 기능이 추가되었습니다.
  * SSE 연결에 대한 하트비트(Heartbeat) 전송 및 수동 연결 종료 기능이 제공됩니다.

* **개선 사항**
  * Swagger 문서에서 서버 포트가 동적으로 반영됩니다.
  * 서버 포트가 8084로 변경되고, Tomcat 연결 관련 설정이 추가되었습니다.

* **버그 수정**
  * Redis 스트림 리스너의 설정 및 초기화가 개선되었습니다.

* **테스트**
  * 테스트 환경에 Mockito 관련 라이브러리가 추가되었습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * SSE(서버 전송 이벤트) 연결 모니터링 기능이 추가되어, 연결 상태를 주기적으로 점검하고 비정상 연결을 정리합니다.
  * 사용자별 이벤트 구독 및 연결 해제(Disconnect) 기능이 추가되었습니다.
  * SSE 연결에 대한 하트비트(Heartbeat) 전송 및 수동 연결 종료 기능이 제공됩니다.

* **개선 사항**
  * Swagger 문서에서 서버 포트가 동적으로 반영됩니다.
  * 서버 포트가 8084로 변경되고, Tomcat 연결 관련 설정이 추가되었습니다.
  * SSE 구독 및 관리가 사용자별로 세분화되어 안정성과 관리성이 향상되었습니다.
  * SSE 구독 타임아웃이 10분으로 단축되고, 타임아웃 시 이벤트 발행 기능이 추가되었습니다.
  * SSE 구독 경로가 명확해지고, 권한 설정에 따라 구독 경로에 대한 접근이 허용됩니다.
  * Redis 스트림 리스너가 Spring Bean으로 관리되도록 개선되었습니다.

* **버그 수정**
  * Redis 스트림 리스너의 설정 및 초기화가 개선되었습니다.

* **테스트**
  * 테스트 환경에 Mockito 관련 라이브러리가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->