### PR TITLE
fix: 사용자 이벤트 목록 및 상태별 목록 조회 버그 수정

### DIFF
--- a/src/main/java/inu/codin/codinticketingapi/CodinTicketingApiApplication.java
+++ b/src/main/java/inu/codin/codinticketingapi/CodinTicketingApiApplication.java
@@ -4,11 +4,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 @EnableFeignClients
 public class CodinTicketingApiApplication {
 
     public static void main(String[] args) {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
         SpringApplication.run(CodinTicketingApiApplication.class, args);
     }
 

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/controller/EventController.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/controller/EventController.java
@@ -35,7 +35,7 @@ public class EventController {
     @Operation(summary = "티켓팅 이벤트 목록 조회 (송도 캠퍼스, 미추홀 캠퍼스)")
     @ApiResponse(responseCode = "200", description = "티켓팅 이벤트 게시물 리스트 조회 성공")
     public ResponseEntity<SingleResponse<EventPageResponse>> getEventList(
-            @Parameter(description = "캠퍼스", example = "SONGDO_CAMPUS, MICHUHOL_CAMPUS") @RequestParam Campus campus,
+            @Parameter(description = "캠퍼스", example = "SONGDO_CAMPUS") @RequestParam Campus campus,
             @Parameter(description = "페이지", example = "0") @RequestParam("page") @NotNull int pageNumber
     ) {
         return ResponseEntity.ok(new SingleResponse<>(200, "티켓팅 이벤트 게시물 리스트 조회 성공",

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/ParticipationResponse.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/ParticipationResponse.java
@@ -1,13 +1,18 @@
 package inu.codin.codinticketingapi.domain.ticketing.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import inu.codin.codinticketingapi.domain.ticketing.entity.Participation;
 import inu.codin.codinticketingapi.domain.ticketing.entity.ParticipationStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "티켓팅 이벤트 수령 생성 응답 DTO")
 public class ParticipationResponse {
 
@@ -19,6 +24,17 @@ public class ParticipationResponse {
 
     @Schema(description = "서명 이미지 URL", example = "https://codin-s3-bucket.s3.ap-northeast-2.amazonaws.com/signature.jpeg")
     private String signatureImgUrl;
+
+    @JsonCreator
+    public ParticipationResponse(
+            @JsonProperty("status") ParticipationStatus status,
+            @JsonProperty("ticketNumber") Integer ticketNumber,
+            @JsonProperty("signatureImgUrl") String signatureImgUrl
+    ) {
+        this.status = status;
+        this.ticketNumber = ticketNumber;
+        this.signatureImgUrl = signatureImgUrl;
+    }
 
     public static ParticipationResponse of(Participation participation) {
         return ParticipationResponse.builder()

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/repository/EventRepository.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/repository/EventRepository.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
 
-    @Query("SELECT e FROM Event e WHERE e.deletedAt IS NULL AND e.campus = :campus")
+    @Query("SELECT e FROM Event e JOIN FETCH e.stock WHERE e.deletedAt IS NULL AND e.campus = :campus")
     Page<Event> findByCampus(@Param("campus") Campus campus, Pageable pageable);
 
     @Query("SELECT e FROM Event e WHERE e.id = :eventId AND e.deletedAt IS NULL")

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/repository/EventRepository.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/repository/EventRepository.java
@@ -32,4 +32,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findByEventStatusAndEventTimeAfterAndDeletedAtIsNull(EventStatus eventStatus, LocalDateTime eventTimeAfter);
 
     Page<Event> findAllByEventStatusAndDeletedAtIsNull(EventStatus eventStatus, Pageable pageable);
+
+    List<Event> findByEventStatusAndEventEndTimeAfterAndDeletedAtIsNull(EventStatus eventStatus, LocalDateTime now);
 }

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/scheduler/StockCheckJob.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/scheduler/StockCheckJob.java
@@ -12,6 +12,7 @@ import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,6 +29,7 @@ public class StockCheckJob implements Job {
     private static final Map<Long, Integer> lastStockMap = new ConcurrentHashMap<>();
 
     @Override
+    @Transactional
     public void execute(JobExecutionContext context) throws JobExecutionException {
         Long eventId = context.getJobDetail().getJobDataMap().getLong("eventId");
         try {

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/EventService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/EventService.java
@@ -52,16 +52,16 @@ public class EventService {
     }
 
     @Transactional(readOnly = true)
-    public EventParticipationHistoryPageResponse getUserEventList(@PositiveOrZero int pageNumber) {
+    public EventParticipationHistoryPageResponse getUserEventList(int pageNumber) {
         String userId = userClientService.fetchUser().getUserId();
-        Pageable pageable = PageRequest.of(pageNumber - 1, 10, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(pageNumber, 10, Sort.by("createdAt").descending());
         return EventParticipationHistoryPageResponse.of(participationRepository.findHistoryByUserId(userId, pageable));
     }
 
     @Transactional(readOnly = true)
-    public EventParticipationHistoryPageResponse getUserEventListByStatus(@PositiveOrZero int pageNumber, @NotNull ParticipationStatus status) {
+    public EventParticipationHistoryPageResponse getUserEventListByStatus(int pageNumber, @NotNull ParticipationStatus status) {
         String userId = userClientService.fetchUser().getUserId();
-        Pageable pageable = PageRequest.of(pageNumber - 1, 10, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(pageNumber, 10, Sort.by("createdAt").descending());
         return EventParticipationHistoryPageResponse.of(participationRepository.findHistoryByUserIdAndCanceled(userId, status, pageable));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,8 +23,8 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
-        format_sql: true
-        use_sql_comments: true
+        #format_sql: true
+        #use_sql_comments: true
         jdbc:
           batch_size: 20
           order_inserts: true


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

#40 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 이벤트가 진행 중인 경우에도 재고 확인 작업이 즉시 시작되고, 이벤트 종료 시까지 반복적으로 실행됩니다.

* **버그 수정**
  * 사용자 이벤트 목록 및 상태별 목록 조회 시 페이지 번호 입력 방식이 변경되어, 페이지네이션 동작이 보다 직관적으로 개선되었습니다.

* **문서화**
  * 이벤트 목록 조회 API의 캠퍼스 예시 값이 하나로 변경되어 문서가 더 명확해졌습니다.

* **기타**
  * 재고 확인 작업의 데이터베이스 처리가 트랜잭션으로 보장됩니다.
  * 일부 Hibernate 설정이 비활성화되었습니다.
  * 응답 객체의 JSON 역직렬화 지원이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->