### PR TITLE
fix: 티켓팅 참여시 이벤트 상태 검증 로직 추가

### DIFF
--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/ParticipationService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/ParticipationService.java
@@ -1,10 +1,10 @@
 package inu.codin.codinticketingapi.domain.ticketing.service;
 
 import inu.codin.codinticketingapi.domain.admin.entity.Event;
+import inu.codin.codinticketingapi.domain.admin.entity.EventStatus;
 import inu.codin.codinticketingapi.domain.ticketing.dto.event.ParticipationCreatedEvent;
 import inu.codin.codinticketingapi.domain.ticketing.dto.response.ParticipationResponse;
 import inu.codin.codinticketingapi.domain.ticketing.entity.Participation;
-import inu.codin.codinticketingapi.domain.ticketing.entity.ParticipationStatus;
 import inu.codin.codinticketingapi.domain.ticketing.entity.Stock;
 import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingErrorCode;
 import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingException;
@@ -57,6 +57,11 @@ public class ParticipationService {
         if (existingParticipation.isPresent()) {
             // 이미 참여한 경우 기존 참여 내용 반환
             return ParticipationResponse.of(existingParticipation.get());
+        }
+
+        // 이벤트 상태 검증
+        if (!event.getEventStatus().equals(EventStatus.ACTIVE)) {
+            throw new TicketingException(TicketingErrorCode.EVENT_NOT_ACTIVE);
         }
         // 재고 줄임
         Stock stock = ticketingService.decrement(eventId);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 이벤트 상태가 ACTIVE가 아닌데도. 이벤트 참여 가능한 버그 발생.
- 이벤트 상태가 ACTIVE일 때만 가능하도록 검증 로직 코드 추가

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 비활성화된 이벤트에 대한 참여가 저장되지 않도록 이벤트 상태 검증이 추가되었습니다. 이제 활성화된 이벤트에만 참여할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->