### PR TITLE
refactor : 티켓 번호 발부를 위한 구현, 티켓팅 재참여 가능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,8 @@ dependencies {
     // Excel
     implementation 'org.apache.poi:poi:5.4.1'
     implementation 'org.apache.poi:poi-ooxml:5.4.1'
+    // serializer
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/config/SecurityConfig.java
+++ b/codin-ticketing-sse/src/main/java/inu/codin/codinticketingsse/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import inu.codin.codinticketingsse.security.filter.SecurityExceptionHandlerFilte
 import inu.codin.codinticketingsse.security.filter.TokenValidationFilter;
 import inu.codin.codinticketingsse.security.jwt.JwtTokenValidator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -26,9 +27,11 @@ import java.util.List;
 @EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
-
     private final JwtTokenValidator jwtTokenValidator;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    @Value("${server.domain}")
+    private String BASE_DOMAIN_URL;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, CorsConfigurationSource corsConfigurationSource) throws Exception {
@@ -63,7 +66,7 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
 
         config.setAllowCredentials(true);
-        config.setAllowedOrigins(List.of("http://localhost:3000"));
+        config.setAllowedOrigins(List.of("http://localhost:3000", BASE_DOMAIN_URL, "https://front-end-dun-mu.vercel.app"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setExposedHeaders(List.of("*"));

--- a/src/main/java/inu/codin/codinticketingapi/CodinTicketingApiApplication.java
+++ b/src/main/java/inu/codin/codinticketingapi/CodinTicketingApiApplication.java
@@ -3,11 +3,13 @@ package inu.codin.codinticketingapi;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.TimeZone;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableScheduling
 public class CodinTicketingApiApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/inu/codin/codinticketingapi/config/RedisConfig.java
+++ b/src/main/java/inu/codin/codinticketingapi/config/RedisConfig.java
@@ -1,5 +1,8 @@
 package inu.codin.codinticketingapi.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -49,12 +52,42 @@ public class RedisConfig {
 
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        // LocalDateTime을 타임스탬프(숫자)가 아닌 ISO-8601 형식의 문자열로 직렬화
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // 2. ObjectMapper를 사용하는 Serializer 생성
+        return getStringObjectRedisTemplate(redisConnectionFactory, objectMapper);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> eventRedisTemplate (RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, String> pingRedisTemplate (RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+
+    private RedisTemplate<String, Object> getStringObjectRedisTemplate(RedisConnectionFactory redisConnectionFactory, ObjectMapper objectMapper) {
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setDefaultSerializer(RedisSerializer.string());
-        redisTemplate.setEnableTransactionSupport(true);
-        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setValueSerializer(serializer);
         return redisTemplate;
     }
 }

--- a/src/main/java/inu/codin/codinticketingapi/config/SchedulerConfig.java
+++ b/src/main/java/inu/codin/codinticketingapi/config/SchedulerConfig.java
@@ -1,0 +1,28 @@
+package inu.codin.codinticketingapi.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+public class SchedulerConfig implements SchedulingConfigurer {
+    private static final int POOL_SIZE = 10;
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+
+        // 스케줄러가 사용할 스레드 풀의 개수를 설정
+        scheduler.setPoolSize(POOL_SIZE);
+
+        // 스레드 이름 접두사 설정
+        scheduler.setThreadNamePrefix("scheduled-task-");
+
+        // 스케줄러 초기화
+        scheduler.initialize();
+
+        // 생성한 스케줄러를 등록
+        taskRegistrar.setTaskScheduler(scheduler);
+    }
+}

--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/controller/swagger/EventAdminController.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/controller/swagger/EventAdminController.java
@@ -93,7 +93,7 @@ public interface EventAdminController {
     ResponseEntity<SingleResponse<Boolean>> changeReceiveStatus(
             @Parameter(description = "이벤트 ID", example = "1", required = true) @PathVariable Long eventId,
             @Parameter(description = "수령 상태를 변경할 사용자 ID", example = "user123", required = true) @PathVariable String userId,
-            @Parameter(description = "서명 이미지", required = true) @RequestPart(value = "eventImage", required = false) MultipartFile eventImage);
+            @RequestPart(value = "eventImage", required = false) @Parameter(description = "서명 이미지", required = true, content = @Content(mediaType = MediaType.IMAGE_JPEG_VALUE)) MultipartFile eventImage);
 
 
     @Operation(summary = "이벤트 잔여 수량 조회", description = "지정된 이벤트의 티켓/상품 잔여 수량을 조회합니다. 관리자/매니저 권한이 필요합니다.")

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/controller/EventController.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/controller/EventController.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/ParticipationResponse.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/ParticipationResponse.java
@@ -10,6 +10,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -25,15 +27,25 @@ public class ParticipationResponse {
     @Schema(description = "서명 이미지 URL", example = "https://codin-s3-bucket.s3.ap-northeast-2.amazonaws.com/signature.jpeg")
     private String signatureImgUrl;
 
+    @Schema(description = "이벤트 종료 시간", example = "2025-07-25T12:00:00")
+    private LocalDateTime eventEndTime;
+
+    @Schema(description = "이벤트 장소 정보", example = "학생회관 301호")
+    private String locationInfo;
+
     @JsonCreator
     public ParticipationResponse(
             @JsonProperty("status") ParticipationStatus status,
             @JsonProperty("ticketNumber") Integer ticketNumber,
-            @JsonProperty("signatureImgUrl") String signatureImgUrl
+            @JsonProperty("signatureImgUrl") String signatureImgUrl,
+            @JsonProperty("eventEndTime") LocalDateTime eventEndTime,
+            @JsonProperty("locationInfo") String locationInfo
     ) {
         this.status = status;
         this.ticketNumber = ticketNumber;
         this.signatureImgUrl = signatureImgUrl;
+        this.eventEndTime = eventEndTime;
+        this.locationInfo = locationInfo;
     }
 
     public static ParticipationResponse of(Participation participation) {
@@ -41,6 +53,8 @@ public class ParticipationResponse {
                 .status(participation.getStatus())
                 .ticketNumber(participation.getTicketNumber())
                 .signatureImgUrl(participation.getSignatureImgUrl())
+                .eventEndTime(participation.getEvent().getEventEndTime())
+                .locationInfo(participation.getEvent().getLocationInfo())
                 .build();
     }
 }

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/redis/RedisEventService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/redis/RedisEventService.java
@@ -1,0 +1,58 @@
+package inu.codin.codinticketingapi.domain.ticketing.redis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisEventService {
+    private final RedisTemplate<String, String> eventRedisTemplate;
+
+    private static final int SOLD_OUT = -1;
+    private static final String AVAILABLE_TICKETS_KEY_PREFIX = "{event:%d}:available";
+
+    // 이벤트 생성 시 티켓 번호 목록을 초기화하는 메서드
+    public void initializeTickets(Long eventId, int totalTickets) {
+        String key = generateKey(eventId);
+        eventRedisTemplate.delete(key);
+
+        for (int i = 1; i <= totalTickets; i++) {
+            eventRedisTemplate.opsForZSet().add(key, String.valueOf(i), i);
+        }
+    }
+
+    // 티켓 번호 하나를 가져오는 메서드
+    public Integer getTicket(Long eventId) {
+        String key = generateKey(eventId);
+        ZSetOperations.TypedTuple<String> ticketNumber = eventRedisTemplate.opsForZSet().popMin(key);
+
+        if (ticketNumber == null || ticketNumber.getValue() == null) {
+            System.out.println("null");
+            return SOLD_OUT;
+        }
+
+        return Integer.parseInt(ticketNumber.getValue());
+    }
+
+    // 취소된 티켓 번호를 다시 반환하는 메서드
+    public void returnTicket(Long eventId, int ticketNumber) {
+        String key = generateKey(eventId);
+
+        eventRedisTemplate.opsForZSet().add(key, String.valueOf(ticketNumber), ticketNumber);
+    }
+
+    public void deleteTickets(Long eventId) {
+        String key = generateKey(eventId);
+
+        eventRedisTemplate.delete(key);
+    }
+
+    private String generateKey(long eventId) {
+        return String.format(AVAILABLE_TICKETS_KEY_PREFIX, eventId);
+    }
+
+}

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/redis/RedisHealthCheckService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/redis/RedisHealthCheckService.java
@@ -41,9 +41,11 @@ public class RedisHealthCheckService {
     private void handleSuccess() {
         int currentFailures = consecutiveFailures.get();
 
-        if (currentFailures > 0) {
-            log.info("Redis 연결이 복구되었습니다.");
+        if (currentFailures >= FAILURE_THRESHOLD) {
+            log.info("Redis 연결이 복구되었습니다. 이벤트 상태를 ACTIVE로 복원합니다.");
             eventService.restoreUpcomingEventsToActive();
+        } else if (currentFailures > 0) {
+            log.info("Redis 연결이 복구되었습니다.");
         }
         // 실패 카운트 리셋
         consecutiveFailures.set(0);

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/redis/RedisHealthCheckService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/redis/RedisHealthCheckService.java
@@ -1,0 +1,62 @@
+package inu.codin.codinticketingapi.domain.ticketing.redis;
+
+import inu.codin.codinticketingapi.domain.ticketing.service.EventService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisHealthCheckService {
+    private final EventService eventService;
+    private final RedisTemplate<String, String> pingRedisTemplate;
+
+    // 연속 실패 횟수를 저장 (동시성 문제를 위해 AtomicInteger 사용)
+    private final AtomicInteger consecutiveFailures = new AtomicInteger(0);
+    // 6번 연속 실패하면 조치 실행 (10초 간격이므로 약 1분간 장애 시)
+    private static final int FAILURE_THRESHOLD = 6;
+
+    // 10초마다 실행 (fixedDelay는 이전 작업이 끝나고 10초 후 실행)
+    @Scheduled(fixedDelay = 10000)
+    public void checkRedisHealth() {
+        try {
+            // 가장 간단한 PING 명령으로 연결 상태 확인
+            pingRedisTemplate.getConnectionFactory().getConnection().ping();
+            handleSuccess();
+            log.info("redis 정상 연결 중");
+        } catch (RedisConnectionFailureException e) {
+            handleFailure();
+        } catch (Exception e) {
+            log.error("Redis 헬스 체크 중 예상치 못한 오류 발생", e);
+            handleFailure();
+        }
+    }
+
+    private void handleSuccess() {
+        int currentFailures = consecutiveFailures.get();
+
+        if (currentFailures > 0) {
+            log.info("Redis 연결이 복구되었습니다.");
+            eventService.restoreUpcomingEventsToActive();
+        }
+        // 실패 카운트 리셋
+        consecutiveFailures.set(0);
+    }
+
+    private void handleFailure() {
+        int failures = consecutiveFailures.incrementAndGet();
+        log.warn("Redis 연결 실패. 연속 실패 횟수: {}회", failures);
+
+        // 정확히 임계값에 도달했을 때 딱 한 번만 실행
+        if (failures == FAILURE_THRESHOLD) {
+            log.error("Redis 장애가 {}초 이상 지속되어 모든 활성 이벤트를 UPCOMING 상태로 변경합니다.", 10 * FAILURE_THRESHOLD);
+            eventService.changeAllActiveEventsToUpcoming();
+        }
+    }
+}

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/repository/EventRepository.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/repository/EventRepository.java
@@ -44,4 +44,13 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     Page<Event> findAllByEventStatusAndDeletedAtIsNull(EventStatus eventStatus, Pageable pageable);
 
     List<Event> findByEventStatusAndEventEndTimeAfterAndDeletedAtIsNull(EventStatus eventStatus, LocalDateTime now);
+
+    List<Event> findByEventStatus(EventStatus eventStatus);
+
+    @Query("""
+            SELECT e
+            FROM Event  e
+            WHERE e.eventStatus = :status and :currentTime BETWEEN e.eventTime AND e.eventEndTime
+            """)
+    List<Event> findAllLiveEvent(@Param("status") EventStatus status, @Param("currentTime") LocalDateTime currentTime);
 }

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/repository/EventRepository.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/repository/EventRepository.java
@@ -5,6 +5,7 @@ import inu.codin.codinticketingapi.domain.admin.entity.EventStatus;
 import inu.codin.codinticketingapi.domain.ticketing.entity.Campus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,7 +18,16 @@ import java.util.Optional;
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
 
-    @Query("SELECT e FROM Event e JOIN FETCH e.stock WHERE e.deletedAt IS NULL AND e.campus = :campus")
+    @EntityGraph(attributePaths = "stock")
+    @Query("""
+            SELECT e
+                 FROM Event e
+                 WHERE e.deletedAt IS NULL AND e.campus = :campus
+                 ORDER BY
+                     CASE WHEN e.eventStatus = 'ENDED' THEN 1 ELSE 0 END ASC,
+                     CASE WHEN e.eventStatus <> 'ENDED' THEN e.eventEndTime END ASC NULLS LAST,
+                     CASE WHEN e.eventStatus = 'ENDED' THEN e.eventEndTime END DESC NULLS LAST
+            """)
     Page<Event> findByCampus(@Param("campus") Campus campus, Pageable pageable);
 
     @Query("SELECT e FROM Event e WHERE e.id = :eventId AND e.deletedAt IS NULL")

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/repository/ParticipationRepository.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/repository/ParticipationRepository.java
@@ -19,40 +19,40 @@ import java.util.Optional;
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
 
     @Query("""
-        SELECT new inu.codin.codinticketingapi.domain.ticketing.dto.response.EventParticipationHistoryDto(
-            e.id,
-            e.title,
-            e.eventImageUrl,
-            e.locationInfo,
-            e.eventTime,
-            e.eventEndTime,
-            p.status
-        )
-        FROM Participation p
-        JOIN p.event e
-        WHERE p.userId = :userId
-          AND e.deletedAt IS NULL
-        ORDER BY p.createdAt DESC
-        """)
+            SELECT new inu.codin.codinticketingapi.domain.ticketing.dto.response.EventParticipationHistoryDto(
+                e.id,
+                e.title,
+                e.eventImageUrl,
+                e.locationInfo,
+                e.eventTime,
+                e.eventEndTime,
+                p.status
+            )
+            FROM Participation p
+            JOIN p.event e
+            WHERE p.userId = :userId
+              AND e.deletedAt IS NULL
+            ORDER BY p.createdAt DESC
+            """)
     Page<EventParticipationHistoryDto> findHistoryByUserId(@Param("userId") String userId, Pageable pageable);
 
     @Query("""
-        SELECT new inu.codin.codinticketingapi.domain.ticketing.dto.response.EventParticipationHistoryDto(
-            e.id,
-            e.title,
-            e.eventImageUrl,
-            e.locationInfo,
-            e.eventTime,
-            e.eventEndTime,
-            p.status
-        )
-        FROM Participation p
-        JOIN p.event e
-        WHERE p.userId = :userId
-          AND e.deletedAt IS NULL
-          AND p.status = :status
-        ORDER BY p.createdAt DESC
-        """)
+            SELECT new inu.codin.codinticketingapi.domain.ticketing.dto.response.EventParticipationHistoryDto(
+                e.id,
+                e.title,
+                e.eventImageUrl,
+                e.locationInfo,
+                e.eventTime,
+                e.eventEndTime,
+                p.status
+            )
+            FROM Participation p
+            JOIN p.event e
+            WHERE p.userId = :userId
+              AND e.deletedAt IS NULL
+              AND p.status = :status
+            ORDER BY p.createdAt DESC
+            """)
     Page<EventParticipationHistoryDto> findHistoryByUserIdAndCanceled(
             @Param("userId") String userId,
             @Param("status") ParticipationStatus status,
@@ -78,10 +78,10 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
     int countByEvent_IdAndStatus(Long eventId, ParticipationStatus status);
 
     @Query("""
-        SELECT p
-        FROM Participation p
-        WHERE p.userId = :userId AND p.event = :event
-        """)
+            SELECT p
+            FROM Participation p
+            WHERE p.userId = :userId AND p.event = :event
+            """)
     Optional<Participation> findByUserIdAndEvent(String userId, Event event);
 
     @Query("""
@@ -95,4 +95,13 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
             @Param("status") ParticipationStatus status,
             @Param("eventIds") List<Long> eventIds
     );
+
+    @Query("""
+            select p
+            from Participation p
+            where p.event.id = :eventId
+              and p.userId = :userId
+              and p.status <> 'CANCELED'
+            """)
+    Optional<Participation> findByUserIdAndEventIdAndNotCanceled(String userId, Long eventId);
 }

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/EventService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/EventService.java
@@ -1,6 +1,7 @@
 package inu.codin.codinticketingapi.domain.ticketing.service;
 
 import inu.codin.codinticketingapi.domain.admin.entity.Event;
+import inu.codin.codinticketingapi.domain.admin.entity.EventStatus;
 import inu.codin.codinticketingapi.domain.ticketing.dto.response.EventDetailResponse;
 import inu.codin.codinticketingapi.domain.ticketing.dto.response.EventPageResponse;
 import inu.codin.codinticketingapi.domain.ticketing.dto.response.EventParticipationHistoryPageResponse;
@@ -15,12 +16,17 @@ import inu.codin.codinticketingapi.domain.user.service.UserClientService;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EventService {
@@ -61,5 +67,38 @@ public class EventService {
         String userId = userClientService.fetchUser().getUserId();
         Pageable pageable = PageRequest.of(pageNumber, 10, Sort.by("createdAt").descending());
         return EventParticipationHistoryPageResponse.of(participationRepository.findHistoryByUserIdAndCanceled(userId, status, pageable));
+    }
+
+    @Transactional
+    public void changeAllActiveEventsToUpcoming() {
+        List<Event> activeEvents = eventRepository.findByEventStatus(EventStatus.ACTIVE);
+
+        if (activeEvents.isEmpty()) {
+            log.info("상태를 변경할 활성 이벤트가 없습니다.");
+
+            return;
+        }
+
+        // 각 이벤트의 상태를 UPCOMING으로 변경
+        activeEvents.forEach(event -> {
+            log.info("이벤트 ID: {}, '{}'의 상태를 ACTIVE에서 UPCOMING으로 변경합니다.", event.getId(), event.getTitle());
+            event.updateStatus(EventStatus.UPCOMING);
+        });
+    }
+
+    @Transactional
+    public void restoreUpcomingEventsToActive() {
+        List<Event> upcomingEvents = eventRepository.findAllLiveEvent(EventStatus.UPCOMING, LocalDateTime.now());
+
+        if (upcomingEvents.isEmpty()) {
+            log.info("ACTIVE로 복구할 UPCOMING 상태의 이벤트가 없습니다.");
+
+            return;
+        }
+
+        upcomingEvents.forEach(event -> {
+            log.info("Redis 복구로 인해 이벤트 ID: {}의 상태를 ACTIVE로 복구합니다.", event.getId());
+            event.updateStatus(EventStatus.ACTIVE);
+        });
     }
 }

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/EventService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/EventService.java
@@ -32,7 +32,8 @@ public class EventService {
 
     @Transactional(readOnly = true)
     public EventPageResponse getEventList(@NotNull Campus campus, @PositiveOrZero int pageNumber) {
-        Pageable pageable = PageRequest.of(pageNumber, 10, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(pageNumber, 10);
+
         return EventPageResponse.from(eventRepository.findByCampus(campus, pageable));
     }
 

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/ParticipationService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/ParticipationService.java
@@ -4,11 +4,11 @@ import inu.codin.codinticketingapi.domain.admin.entity.Event;
 import inu.codin.codinticketingapi.domain.admin.entity.EventStatus;
 import inu.codin.codinticketingapi.domain.ticketing.dto.event.ParticipationCreatedEvent;
 import inu.codin.codinticketingapi.domain.ticketing.dto.response.ParticipationResponse;
+import inu.codin.codinticketingapi.domain.ticketing.entity.Department;
 import inu.codin.codinticketingapi.domain.ticketing.entity.Participation;
-import inu.codin.codinticketingapi.domain.ticketing.entity.ParticipationStatus;
-import inu.codin.codinticketingapi.domain.ticketing.entity.Stock;
 import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingErrorCode;
 import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingException;
+import inu.codin.codinticketingapi.domain.ticketing.redis.RedisEventService;
 import inu.codin.codinticketingapi.domain.ticketing.redis.RedisParticipationService;
 import inu.codin.codinticketingapi.domain.ticketing.repository.EventRepository;
 import inu.codin.codinticketingapi.domain.ticketing.repository.ParticipationRepository;
@@ -18,18 +18,22 @@ import inu.codin.codinticketingapi.domain.user.exception.UserException;
 import inu.codin.codinticketingapi.domain.user.service.UserClientService;
 import inu.codin.codinticketingapi.security.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ParticipationService {
 
     private final TicketingService ticketingService;
     private final UserClientService userClientService;
+    private final RedisEventService redisEventService;
 
     private final EventRepository eventRepository;
     private final ParticipationRepository participationRepository;
@@ -40,52 +44,20 @@ public class ParticipationService {
     @Transactional
     public ParticipationResponse saveParticipation(Long eventId) {
         UserInfoResponse userInfoResponse = userClientService.fetchUser();
-        // 유저 티켓팅 정보가 존재하는지 검증
+        Event findEvent = findEvent(eventId);
+
+        // 유저 정보가 존재하는지 검증
         if (userInfoResponse.getDepartment() == null || userInfoResponse.getStudentId() == null) {
             throw new UserException(UserErrorCode.NOT_EXIST_PARTICIPATION_DATA);
         }
-        Event event = eventRepository.findById(eventId).orElseThrow(() -> new TicketingException(TicketingErrorCode.EVENT_NOT_FOUND));
-
-        // 캐시에서 먼저 조회
-        Optional<ParticipationResponse> cached = redisParticipationService.getCachedParticipation(userInfoResponse.getUserId(), eventId);
-        if (cached.isPresent()) {
-            return cached.get();
-        }
-
-        // 이미 참여한 사용자인지 확인
-        Optional<Participation> existingParticipation = participationRepository.findByUserIdAndEvent(userInfoResponse.getUserId(), event);
-
-        if (existingParticipation.isPresent()) {
-            Participation participation = existingParticipation.get();
-            // 취소 상태가 아니면 기존 참여 정보 반환
-            if (participation.getStatus() != ParticipationStatus.CANCELED) {
-                return ParticipationResponse.of(participation);
-            }
-            // CANCELED 상태면 재참여 가능 (아래 이벤트 참여 로직 진행)
-        }
 
         // 이벤트 상태 검증
-        if (event.getEventStatus() != EventStatus.ACTIVE) {
+        if (findEvent.getEventStatus() != EventStatus.ACTIVE) {
             throw new TicketingException(TicketingErrorCode.EVENT_NOT_ACTIVE);
         }
-        // 재고 줄임
-        Stock stock = ticketingService.decrement(eventId);
 
-        // 사용자 번호표
-        int ticketNumber = stock.getInitialStock() - stock.getStock();
-
-        Participation participation = Participation.builder()
-                .event(event)
-                .ticketNumber(ticketNumber)
-                .userInfoResponse(userInfoResponse)
-                .build();
-
-        Participation savedParticipation = participationRepository.save(participation);
-
-        // 참여 생성 이벤트 발행
-        eventPublisher.publishEvent(new ParticipationCreatedEvent(savedParticipation));
-
-        return ParticipationResponse.of(savedParticipation);
+       return findParticipationResponse(userInfoResponse.getUserId(), findEvent.getId())
+               .orElseGet(() -> createParticipation(findEvent, userInfoResponse));
     }
 
     @Transactional(readOnly = true)
@@ -99,8 +71,7 @@ public class ParticipationService {
         }
 
         // 캐시 미스 시 DB 조회
-        Event event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new TicketingException(TicketingErrorCode.EVENT_NOT_FOUND));
+        Event event = findEvent(eventId);
         Participation participation = participationRepository.findByUserIdAndEvent(userId, event)
                 .orElseThrow(() -> new TicketingException(TicketingErrorCode.PARTICIPATION_NOT_FOUND));
         ParticipationResponse response = ParticipationResponse.of(participation);
@@ -109,5 +80,52 @@ public class ParticipationService {
         redisParticipationService.cacheParticipation(userId, eventId, participation);
 
         return response;
+    }
+
+    private Event findEvent(Long eventId) {
+        return eventRepository.findById(eventId)
+                .orElseThrow(() -> new TicketingException(TicketingErrorCode.EVENT_NOT_FOUND));
+    }
+
+    private ParticipationResponse createParticipation(Event event, UserInfoResponse userInfoResponse) {
+        try {
+            // 재고 줄임
+            ticketingService.decrement(event.getId());
+            Integer ticketNumber = redisEventService.getTicket(event.getId());
+            log.info("ticketNumber: {}", ticketNumber);
+
+            Participation participation = Participation.builder()
+                    .event(event)
+                    .ticketNumber(ticketNumber)
+                    .userInfoResponse(userInfoResponse)
+                    .build();
+
+            Participation savedParticipation = participationRepository.save(participation);
+
+            // 참여 생성 이벤트 발행
+            eventPublisher.publishEvent(new ParticipationCreatedEvent(savedParticipation));
+            log.info("새로운 참가자 : {}", event.getId());
+            return ParticipationResponse.of(savedParticipation);
+        } catch (DataIntegrityViolationException dup) {
+
+            return participationRepository.findByUserIdAndEventIdAndNotCanceled(userInfoResponse.getUserId(), event.getId())
+                    .map(ParticipationResponse::of)
+                    .orElseThrow(() -> dup);
+        }
+    }
+
+    private Optional<ParticipationResponse> findParticipationResponse(String userId, Long eventId) {
+        // 1. 캐시에서 먼저 조회
+        Optional<ParticipationResponse> cached = redisParticipationService.getCachedParticipation(userId, eventId);
+        log.info("cache hit : {}", eventId);
+
+        if (cached.isPresent()) {
+
+            return cached;
+        }
+
+        // 2. 캐시에 없으면 DB에서 조회 및 상태 확인
+        return participationRepository.findByUserIdAndEventIdAndNotCanceled(userId, eventId)
+                .map(ParticipationResponse::of);
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

- 티켓 번호 발부를 redis로 위임
- redis 헬스체크 추가
- redis 다운 시 ACTIVE 이벤트 UPCOMING으로 변경
- redis up 상태일 시 진행시간인 이벤트 다시 ACTIVE 로 변경