### PR TITLE
feat: 티켓팅 이벤트 참여 상태 조회 기능 추가

### DIFF
--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/controller/TicketingController.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/controller/TicketingController.java
@@ -34,6 +34,19 @@ public class TicketingController {
                 participationService.findParticipationByEvent(eventId)));
     }
 
+
+    /** 유저의 특정 이벤트 티켓팅 단순 참여 상태(Boolean) 반환 */
+    @GetMapping("/participation/check/{eventId}")
+    @Operation(summary = "유저의 특정 이벤트 티켓팅 단순 참여 상태(Boolean) 반환 - (참여, 서명 상태 -> true / 미참여, 취소 -> false)")
+    @ApiResponse(responseCode = "200", description = "티켓팅 이벤트 단순 참여 상태 조회 성공")
+    public ResponseEntity<SingleResponse<Boolean>> readParticipationByEvent(
+            @PathVariable Long eventId
+    ) {
+        participationService.findParticipationByEvent(eventId);
+        return ResponseEntity.ok(new SingleResponse<>(200, "티켓팅 이벤트 단순 참여상태 조회 성공",
+                participationService.isUserParticipatedInEvent(eventId)));
+    }
+
     /** 특정 티켓팅 이벤트에 티켓팅 참여 (교환권 부여) */
     @PostMapping("/join/{eventId}")
     @Operation(summary = "특정 티켓팅 이벤트에 티켓팅 참여 (교환권 부여)")

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/ParticipationService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/ParticipationService.java
@@ -128,4 +128,10 @@ public class ParticipationService {
         return participationRepository.findByUserIdAndEventIdAndNotCanceled(userId, eventId)
                 .map(ParticipationResponse::of);
     }
+
+    @Transactional(readOnly = true)
+    public Boolean isUserParticipatedInEvent(Long eventId) {
+        String userId = SecurityUtil.getUserId();
+        return participationRepository.findByUserIdAndEventIdAndNotCanceled(userId, eventId).isPresent();
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- endpoint: `/event/participation/check/{eventId}`
- 티켓팅 완료된 상태의 이벤트 페이지에서 유저의 티켓팅 참여 상태조회가 불가능해 기능 추가