### PR TITLE
feat: 티켓팅 이벤트 상세 정보 조회에 참여 상태 추가

### DIFF
--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/controller/TicketingController.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/controller/TicketingController.java
@@ -34,18 +34,6 @@ public class TicketingController {
                 participationService.findParticipationByEvent(eventId)));
     }
 
-
-    /** 유저의 특정 이벤트 티켓팅 단순 참여 상태(Boolean) 반환 */
-    @GetMapping("/participation/check/{eventId}")
-    @Operation(summary = "유저의 특정 이벤트 티켓팅 단순 참여 상태(Boolean) 반환 - (참여, 서명 상태 -> true / 미참여, 취소 -> false)")
-    @ApiResponse(responseCode = "200", description = "티켓팅 이벤트 단순 참여 상태 조회 성공")
-    public ResponseEntity<SingleResponse<Boolean>> readParticipationByEvent(
-            @PathVariable Long eventId
-    ) {
-        return ResponseEntity.ok(new SingleResponse<>(200, "티켓팅 이벤트 단순 참여상태 조회 성공",
-                participationService.isUserParticipatedInEvent(eventId)));
-    }
-
     /** 특정 티켓팅 이벤트에 티켓팅 참여 (교환권 부여) */
     @PostMapping("/join/{eventId}")
     @Operation(summary = "특정 티켓팅 이벤트에 티켓팅 참여 (교환권 부여)")

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/EventDetailResponse.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/dto/response/EventDetailResponse.java
@@ -56,10 +56,13 @@ public class EventDetailResponse {
     @Schema(description = "이벤트 상태", example = "UPCOMING, ACTIVE, ENDED")
     private EventStatus eventStatus;
 
-    @Schema(description = "유저 티켓팅 정보 존재 여부", example = "true, false")
+    @Schema(description = "유저 티켓팅 참여 정보 존재 여부", example = "true, false")
     private boolean isExistParticipationData;
 
-    public static EventDetailResponse of(Event event,  boolean isExistParticipationData) {
+    @Schema(description = "유저의 특정 이벤트 티켓팅 단순 참여 상태(Boolean) 반환 - (참여, 서명 상태 -> true / 미참여, 취소 -> false)", example = "true, false")
+    private boolean isUserParticipatedInEvent;
+
+    public static EventDetailResponse of(Event event,  boolean isExistParticipationData, boolean isUserParticipatedInEvent) {
         return EventDetailResponse.builder()
                 .eventId(event.getId())
                 .eventTime(event.getEventTime())
@@ -75,6 +78,7 @@ public class EventDetailResponse {
                 .promotionLink(event.getPromotionLink())
                 .eventStatus(event.getEventStatus())
                 .isExistParticipationData(isExistParticipationData)
+                .isUserParticipatedInEvent(isUserParticipatedInEvent)
                 .build();
     }
 }

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/EventService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/EventService.java
@@ -35,6 +35,7 @@ public class EventService {
     private final ParticipationRepository participationRepository;
 
     private final UserClientService userClientService;
+    private final ParticipationService participationService;
 
     @Transactional(readOnly = true)
     public EventPageResponse getEventList(@NotNull Campus campus, @PositiveOrZero int pageNumber) {
@@ -48,11 +49,12 @@ public class EventService {
         UserInfoResponse userInfoResponse = userClientService.fetchUser();
         // 유저 티켓팅 정보가 존재하는지 검증
         boolean isExistParticipationData = userInfoResponse.getDepartment() != null && userInfoResponse.getStudentId() != null;
+        boolean isUserParticipatedInEvent = participationService.isUserParticipatedInEvent(eventId);
 
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new TicketingException(TicketingErrorCode.EVENT_NOT_FOUND));
 
-        return EventDetailResponse.of(event, isExistParticipationData);
+        return EventDetailResponse.of(event, isExistParticipationData, isUserParticipatedInEvent);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
불필요한 '유저의 특정 이벤트 티켓팅 단순 참여 상태(Boolean) 반환' 엔드포인트 삭제

## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

#54 부분을 삭제 이후 변경

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- '티켓팅 이벤트 상세 정보 조회' 엔드포인트 : `/api/ticketing/event/{eventId}` 부분에 반환 스키마 추가
- 유저의 특정 이벤트 티켓팅 단순 참여 상태(Boolean) 반환 - (참여, 서명 상태 -> true / 미참여, 취소 -> false)
- 변수명 : `isUserParticipatedInEvent`