### PR TITLE
feat: 유저 티켓팅 정보 검증 조건에 name이 null이거나 길이가 2 이하일 경우 false 추가

### DIFF
--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/EventService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/service/EventService.java
@@ -48,7 +48,11 @@ public class EventService {
     public EventDetailResponse getEventDetail(Long eventId) {
         UserInfoResponse userInfoResponse = userClientService.fetchUser();
         // 유저 티켓팅 정보가 존재하는지 검증
-        boolean isExistParticipationData = userInfoResponse.getDepartment() != null && userInfoResponse.getStudentId() != null;
+        boolean isExistParticipationData =
+                userInfoResponse.getDepartment() != null
+                        && userInfoResponse.getStudentId() != null
+                        && userInfoResponse.getName() != null
+                        && userInfoResponse.getName().length() > 2;
         boolean isUserParticipatedInEvent = participationService.isUserParticipatedInEvent(eventId);
 
         Event event = eventRepository.findById(eventId)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ❌

## 📝 작업 내용

> 유저 정보 등록을 유도하는 분기인 isExistParticipationData 필드에 name이 존재하지 않거나, 2글자 이하인 경우도 분기할 수 있도록
false로 지정하는 조건 추가

### 스크린샷 (선택)
<img width="525" height="136" alt="스크린샷 2025-11-25 오후 7 21 06" src="https://github.com/user-attachments/assets/75218a97-f75b-4703-9fd3-50ae2bb2787b" />

## 💬 리뷰 요구사항(선택)

> ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 이벤트 상세 조회 시 참여 데이터 유효성 검증 기준을 강화했습니다. 사용자 정보의 완전성을 더 철저히 확인하여 더 정확한 참여 상태 표시를 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->