### PR TITLE
feat: 티켓팅 엑셀 내보내기에서 상품 수령을 완료한 유저만 포함되도록 조건 추가

### DIFF
--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/service/ExcelService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/service/ExcelService.java
@@ -5,6 +5,7 @@ import inu.codin.codinticketingapi.domain.admin.entity.Event;
 import inu.codin.codinticketingapi.domain.admin.exception.ExcelErrorCode;
 import inu.codin.codinticketingapi.domain.admin.exception.ExcelException;
 import inu.codin.codinticketingapi.domain.ticketing.entity.Participation;
+import inu.codin.codinticketingapi.domain.ticketing.entity.ParticipationStatus;
 import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingErrorCode;
 import inu.codin.codinticketingapi.domain.ticketing.exception.TicketingException;
 import inu.codin.codinticketingapi.domain.ticketing.repository.EventRepository;
@@ -97,9 +98,9 @@ public class ExcelService {
         }
     }
 
+    // 완료된 참여자 목록 조회
     private List<Participation> getParticipation(Long eventId) {
-
-        return participationRepository.findAllByEvent_Id(eventId);
+        return participationRepository.findAllByEvent_IdAndStatus(eventId, ParticipationStatus.COMPLETED);
     }
 
     private void populateDataRows(Sheet sheet, List<Participation> participationList) {

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/repository/ParticipationRepository.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/repository/ParticipationRepository.java
@@ -67,6 +67,9 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
     @EntityGraph(attributePaths = {"event"})
     List<Participation> findAllByEvent_Id(Long eventId);
 
+    @EntityGraph(attributePaths = {"event"})
+    List<Participation> findAllByEvent_IdAndStatus(Long eventId, ParticipationStatus status);
+
     @Query("""
                 SELECT p.signatureImgUrl
                 FROM Participation p


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ❌

## 📝 작업 내용

> 티켓팅 액셀 내보내기에서 기존에는 모든 참여자를 전부 포함했지만,
학생회의 실제 수령자만 명단에 기록할 필요에 따라 수령 완료 상태의 user만 액셀에 포함되도록 쿼리를 수정했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항
- 엑셀 내보내기 기능을 개선하여 완료된 참여 기록만 포함하도록 수정되었습니다.

## 새로운 기능
- 이벤트 및 참여 상태별로 기록을 필터링할 수 있는 기능이 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->