### PR TITLE
fix: 티켓팅 비밀번호를 JSON으로 파싱함에 따라 number 처리 되는 문제 수정

### DIFF
--- a/src/main/java/inu/codin/codinticketingapi/domain/admin/service/ExcelService.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/admin/service/ExcelService.java
@@ -61,7 +61,7 @@ public class ExcelService {
 
         createHeaderRow(sheet);
 
-        List<Participation> participationList = getParticipation(event.getId());
+        List<Participation> participationList = getCompletedParticipation(event.getId());
         populateDataRows(sheet, participationList);
 
         autoSizeAllColumns(sheet);
@@ -99,7 +99,7 @@ public class ExcelService {
     }
 
     // 완료된 참여자 목록 조회
-    private List<Participation> getParticipation(Long eventId) {
+    private List<Participation> getCompletedParticipation(Long eventId) {
         return participationRepository.findAllByEvent_IdAndStatus(eventId, ParticipationStatus.COMPLETED);
     }
 

--- a/src/main/java/inu/codin/codinticketingapi/domain/ticketing/controller/TicketingController.java
+++ b/src/main/java/inu/codin/codinticketingapi/domain/ticketing/controller/TicketingController.java
@@ -51,7 +51,7 @@ public class TicketingController {
     @ApiResponse(responseCode = "200", description = "관리자 비밀번호로 수령 확인 성공")
     public ResponseEntity<SingleResponse<?>> updateParticipationStatusByPassword(
             @Parameter(description = "이벤트 ID", example = "1111") @PathVariable Long eventId,
-            @Parameter(description = "관리자 비밀번호 (4자리)", example = "1234") @RequestPart("password") String adminPassword,
+            @Parameter(description = "관리자 비밀번호 (4자리)", example = "1234") @RequestParam("password") String adminPassword,
             @Parameter(description = "서명 이미지 파일") @RequestPart("signatureImage") MultipartFile signatureImage
     ) {
         ticketingService.processParticipationSuccess(eventId, adminPassword, signatureImage);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ❌

## 📝 작업 내용

> @RequestPart로 인해 비밀번호 값을 JSON으로 파싱하려고 함에 따라 number로 처리되어 
비밀번호가 0으로 시작할 시에, 오류가 발생하는 문제 존재

-> @RequestParam으로 형식을 변경
-> multipart-from data 형태이므로 해당 데이터가 URL 쿼리로 나가지 않는 것을 고려

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 엑셀 내보내기에서 완료된 참가자 정보만 표시하도록 수정
  * 참가 상태 업데이트 시 비밀번호 매개변수 처리 방식 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->